### PR TITLE
Support RS erasure decoding

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -2,8 +2,8 @@ name: python-release
 
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -66,7 +66,7 @@ jobs:
         run: cargo check --features object_store
 
       - name: Check all features
-        run: cargo check --features kerberos,token,object_store
+        run: cargo check --features kerberos,token,object_store,rs
 
   test:
     strategy:
@@ -109,4 +109,4 @@ jobs:
           echo "$GITHUB_WORKSPACE/hadoop-3.3.6/bin" >> $GITHUB_PATH
 
       - name: Run tests
-        run: cargo test --features kerberos,token,object_store,integration-test -- --test-threads=1
+        run: cargo test --features kerberos,token,object_store,integration-test,rs -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +504,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -517,6 +537,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "protobuf-src",
+ "reed-solomon-erasure",
  "roxmltree",
  "socket2",
  "tempfile",
@@ -626,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -634,6 +655,15 @@ name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "is-terminal"
@@ -714,6 +744,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +770,15 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "memchr"
@@ -842,7 +887,7 @@ dependencies = [
  "futures",
  "humantime 2.1.0",
  "itertools",
- "parking_lot",
+ "parking_lot 0.12.1",
  "percent-encoding",
  "snafu",
  "tokio",
@@ -859,12 +904,37 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -875,7 +945,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
 ]
@@ -1006,7 +1076,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -1073,11 +1143,34 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "reed-solomon-erasure"
+version = "6.0.0"
+source = "git+https://github.com/Senbei64/reed-solomon-erasure?branch=SNB/23C24_external_matrix#4307577d92ffd4a75e3e4a619ef25b79d99d2c0b"
+dependencies = [
+ "cc",
+ "libc",
+ "libm",
+ "lru",
+ "parking_lot 0.11.2",
+ "smallvec",
+ "spin",
 ]
 
 [[package]]
@@ -1218,6 +1311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,7 +1358,7 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ dependencies = [
 [[package]]
 name = "reed-solomon-erasure"
 version = "6.0.0"
-source = "git+https://github.com/Senbei64/reed-solomon-erasure?branch=SNB/23C24_external_matrix#4307577d92ffd4a75e3e4a619ef25b79d99d2c0b"
+source = "git+https://github.com/Kimahriman/reed-solomon-erasure?branch=SNB/23C24_external_matrix#4307577d92ffd4a75e3e4a619ef25b79d99d2c0b"
 dependencies = [
  "cc",
  "libc",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -24,12 +24,11 @@ doc = false
 [dependencies]
 bytes = "1.4" 
 env_logger = "0.10"
-hdfs-native = { version = "0.1.0", path = "../rust", features=["token", "kerberos"] }
+hdfs-native = { version = "0.1.0", path = "../rust", features=["token", "kerberos", "rs"] }
 log = "0.4"
 pyo3 = { version = "0.19.0", features = ["extension-module", "abi3", "abi3-py37"] }
 thiserror = "1.0.43"
 tokio = { version = "1.28", features = ["rt-multi-thread"] }
-
 
 [features]
 protobuf-src = ["hdfs-native/protobuf-src"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4"
 object_store = { version = "0.6", optional = true }
 prost = "0.11"
 prost-types = "0.11"
-reed-solomon-erasure = { version = "6.0.0", optional = true, git = "https://github.com/Senbei64/reed-solomon-erasure", branch = "SNB/23C24_external_matrix", features = ["simd-accel"] }
+reed-solomon-erasure = { version = "6.0.0", optional = true, git = "https://github.com/Kimahriman/reed-solomon-erasure", branch = "SNB/23C24_external_matrix", features = ["simd-accel"] }
 roxmltree = "0.18"
 socket2 = "0.5"
 thiserror = "1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4"
 object_store = { version = "0.6", optional = true }
 prost = "0.11"
 prost-types = "0.11"
+reed-solomon-erasure = { version = "6.0.0", optional = true, git = "https://github.com/Senbei64/reed-solomon-erasure", branch = "SNB/23C24_external_matrix", features = ["simd-accel"] }
 roxmltree = "0.18"
 socket2 = "0.5"
 thiserror = "1"
@@ -45,4 +46,5 @@ which = "4"
 kerberos = ["libgssapi"]
 object_store = ["dep:object_store", "async-trait", "chrono"]
 token = ["gsasl-sys"]
+rs = ["reed-solomon-erasure"]
 integration-test = []

--- a/rust/minidfs/src/main/java/Main.java
+++ b/rust/minidfs/src/main/java/Main.java
@@ -67,7 +67,8 @@ public class Main {
 
         int numDataNodes = 1;
         if (flags.contains("ec")) {
-            numDataNodes = 5;
+            // Enough for the largest EC policy
+            numDataNodes = 14;
         }
 
         HdfsConfiguration hdfsConf = new HdfsConfiguration(conf);
@@ -75,7 +76,7 @@ public class Main {
             .nameNodePort(9000)
             .nameNodeHttpPort(9870)
             .nnTopology(nnTopology)
-            .numDataNodes(5)
+            .numDataNodes(numDataNodes)
             .build();
 
         hdfsConf.writeXml(new FileOutputStream("target/test/core-site.xml"));
@@ -91,8 +92,13 @@ public class Main {
         if (flags.contains("ec")) {
             DistributedFileSystem fs = dfs.getFileSystem(activeNamenode);
             fs.enableErasureCodingPolicy("RS-3-2-1024k");
-            fs.mkdirs(new Path("/ec"), new FsPermission("755"));
-            fs.setErasureCodingPolicy(new Path("/ec"), "RS-3-2-1024k");
+            fs.enableErasureCodingPolicy("RS-10-4-1024k");
+            fs.mkdirs(new Path("/ec-3-2"), new FsPermission("755"));
+            fs.mkdirs(new Path("/ec-6-3"), new FsPermission("755"));
+            fs.mkdirs(new Path("/ec-10-4"), new FsPermission("755"));
+            fs.setErasureCodingPolicy(new Path("/ec-3-2"), "RS-3-2-1024k");
+            fs.setErasureCodingPolicy(new Path("/ec-6-3"), "RS-6-3-1024k");
+            fs.setErasureCodingPolicy(new Path("/ec-10-4"), "RS-10-4-1024k");
         }
 
         if (flags.contains("token")) {

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -10,7 +10,7 @@ use url::Url;
 use crate::common::config::Configuration;
 use crate::error::{HdfsError, Result};
 use crate::file::{FileReader, FileWriter};
-use crate::hdfs::datanode::resolve_ec_policy;
+use crate::hdfs::ec::resolve_ec_policy;
 use crate::hdfs::protocol::NamenodeProtocol;
 use crate::hdfs::proxy::NameServiceProxy;
 use crate::proto::hdfs::hdfs_file_status_proto::FileType;

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -3,6 +3,8 @@ use std::io;
 #[cfg(feature = "kerberos")]
 use libgssapi::error::Error as GssapiError;
 use prost::DecodeError;
+#[cfg(feature = "rs")]
+use reed_solomon_erasure::Error as RSError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -23,6 +25,9 @@ pub enum HdfsError {
     IsADirectoryError(String),
     #[error("unsupported erasure coding policy")]
     UnsupportedErasureCodingPolicy(String),
+    #[cfg(feature = "rs")]
+    #[error("erasure coding error")]
+    ErasureCodingError(#[from] RSError),
     #[error("operation not supported")]
     UnsupportedFeature(String),
     #[error("interal error, this shouldn't happen")]

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -4,11 +4,11 @@ use bytes::{Bytes, BytesMut};
 use futures::future::join_all;
 use log::debug;
 
+use crate::hdfs::datanode::{BlockReader, BlockWriter};
+use crate::hdfs::ec::EcSchema;
 use crate::hdfs::protocol::NamenodeProtocol;
 use crate::proto::hdfs;
 use crate::Result;
-
-use crate::hdfs::datanode::{BlockReader, BlockWriter, EcSchema};
 
 pub struct FileReader {
     status: hdfs::HdfsFileStatusProto,

--- a/rust/src/hdfs/ec.rs
+++ b/rust/src/hdfs/ec.rs
@@ -188,12 +188,12 @@ fn gen_rs_matrix(data_units: usize, parity_units: usize) -> Result<Matrix<Field>
 
 #[cfg(test)]
 mod test {
-    use crate::hdfs::ec::gen_rs_matrix;
     use crate::Result;
 
     #[cfg(feature = "rs")]
     #[test]
     fn test_build_rs_matrix() -> Result<()> {
+        use super::gen_rs_matrix;
         use reed_solomon_erasure::matrix::Matrix;
 
         // These examples were taken directly from the matrices created by Hadoop via RSUtil.genCauchyMatrix

--- a/rust/src/hdfs/ec.rs
+++ b/rust/src/hdfs/ec.rs
@@ -1,0 +1,247 @@
+use bytes::{Bytes, BytesMut};
+#[cfg(feature = "rs")]
+use reed_solomon_erasure::{
+    galois_8::{add, div, Field, ReedSolomon},
+    matrix::Matrix,
+};
+
+use crate::{proto::hdfs, HdfsError, Result};
+
+const RS_CODEC_NAME: &str = "rs";
+const RS_LEGACY_CODEC_NAME: &str = "rs-legacy";
+const XOR_CODEC_NAME: &str = "xor";
+const DEFAULT_EC_CELL_SIZE: usize = 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub(crate) struct EcSchema {
+    pub codec_name: String,
+    pub data_units: usize,
+    pub parity_units: usize,
+    pub cell_size: usize,
+}
+
+impl EcSchema {
+    pub(crate) fn row_size(&self) -> usize {
+        self.cell_size * self.data_units
+    }
+
+    /// Returns the cell number (0-based) containing the offset
+    pub(crate) fn cell_for_offset(&self, offset: usize) -> usize {
+        offset / self.cell_size
+    }
+
+    pub(crate) fn row_for_cell(&self, cell_id: usize) -> usize {
+        cell_id / self.data_units
+    }
+
+    pub(super) fn offset_for_row(&self, row_id: usize) -> usize {
+        row_id * self.cell_size
+    }
+
+    pub(crate) fn max_offset(&self, mut index: usize, block_size: usize) -> usize {
+        // If it's a parity cell, it's the same length as the first block
+        if index >= self.data_units {
+            index = 0;
+        }
+
+        // Get the number of bytes in the vertical slice for full rows
+        let full_rows = block_size / self.row_size();
+        let full_row_bytes = full_rows * self.row_size();
+
+        let remaining_block_bytes = block_size - full_row_bytes;
+
+        let bytes_in_last_row: usize = if remaining_block_bytes < index as usize * self.cell_size {
+            0
+        } else if remaining_block_bytes > (index + 1) as usize * self.cell_size {
+            self.cell_size
+        } else {
+            remaining_block_bytes - index as usize * self.cell_size
+        };
+        full_rows * self.cell_size + bytes_in_last_row
+    }
+
+    pub(crate) fn ec_decode(
+        &self,
+        mut vertical_stripes: Vec<Option<BytesMut>>,
+    ) -> Result<Vec<Bytes>> {
+        let mut cells: Vec<Bytes> = Vec::new();
+        if !vertical_stripes
+            .iter()
+            .enumerate()
+            .all(|(index, stripe)| stripe.is_some() || index >= self.data_units)
+        {
+            match self.codec_name.as_str() {
+                #[cfg(feature = "rs")]
+                "rs" => {
+                    let matrix = gen_rs_matrix(self.data_units, self.parity_units)?;
+                    let decoder =
+                        ReedSolomon::new_with_matrix(self.data_units, self.parity_units, matrix)?;
+                    decoder.reconstruct_data(&mut vertical_stripes)?;
+                }
+                codec => {
+                    return Err(HdfsError::UnsupportedErasureCodingPolicy(format!(
+                        "codec: {}",
+                        codec
+                    )))
+                }
+            }
+        }
+
+        while vertical_stripes[0].as_ref().is_some_and(|b| !b.is_empty()) {
+            for index in 0..self.data_units {
+                cells.push(
+                    vertical_stripes[index as usize]
+                        .as_mut()
+                        .unwrap()
+                        .split_to(self.cell_size)
+                        .freeze(),
+                )
+            }
+        }
+
+        Ok(cells)
+    }
+}
+
+/// Hadoop hard codes a default list of EC policies by ID
+pub(crate) fn resolve_ec_policy(policy: &hdfs::ErasureCodingPolicyProto) -> Result<EcSchema> {
+    if let Some(schema) = policy.schema.as_ref() {
+        return Ok(EcSchema {
+            codec_name: schema.codec_name.clone(),
+            data_units: schema.data_units as usize,
+            parity_units: schema.parity_units as usize,
+            cell_size: policy.cell_size() as usize,
+        });
+    }
+
+    match policy.id {
+        // RS-6-3-1024k
+        1 => Ok(EcSchema {
+            codec_name: RS_CODEC_NAME.to_string(),
+            data_units: 6,
+            parity_units: 3,
+            cell_size: DEFAULT_EC_CELL_SIZE,
+        }),
+        // RS-3-2-1024k
+        2 => Ok(EcSchema {
+            codec_name: RS_CODEC_NAME.to_string(),
+            data_units: 3,
+            parity_units: 2,
+            cell_size: DEFAULT_EC_CELL_SIZE,
+        }),
+        // RS-6-3-1024k
+        3 => Ok(EcSchema {
+            codec_name: RS_LEGACY_CODEC_NAME.to_string(),
+            data_units: 6,
+            parity_units: 3,
+            cell_size: DEFAULT_EC_CELL_SIZE,
+        }),
+        // XOR-2-1-1024k
+        4 => Ok(EcSchema {
+            codec_name: XOR_CODEC_NAME.to_string(),
+            data_units: 2,
+            parity_units: 1,
+            cell_size: DEFAULT_EC_CELL_SIZE,
+        }),
+        // RS-10-4-1024k
+        5 => Ok(EcSchema {
+            codec_name: RS_CODEC_NAME.to_string(),
+            data_units: 10,
+            parity_units: 4,
+            cell_size: DEFAULT_EC_CELL_SIZE,
+        }),
+        _ => Err(HdfsError::UnsupportedErasureCodingPolicy(format!(
+            "ID: {}",
+            policy.id
+        ))),
+    }
+}
+
+#[cfg(feature = "rs")]
+fn gen_rs_matrix(data_units: usize, parity_units: usize) -> Result<Matrix<Field>> {
+    // Identity matrix for the first `data_rows` rows
+    let mut data_rows: Vec<Vec<u8>> = (0..data_units)
+        .map(|i| {
+            let mut row = vec![0u8; data_units];
+            row[i] = 1;
+            row
+        })
+        .collect();
+
+    // For parity rows, inverse of i ^ j, or 0 (described as 1 / (i + j) | i != j)
+    let mut parity_rows: Vec<Vec<u8>> = (data_units..(data_units + parity_units))
+        .map(|i| {
+            let row: Vec<u8> = (0..data_units)
+                .map(|j| match add(i as u8, j as u8) {
+                    0 => 0,
+                    mult => div(1, mult),
+                })
+                .collect();
+            row
+        })
+        .collect();
+
+    data_rows.append(&mut parity_rows);
+
+    Ok(Matrix::new_with_data(data_rows))
+}
+
+#[cfg(test)]
+mod test {
+    use crate::hdfs::ec::gen_rs_matrix;
+    use crate::Result;
+
+    #[cfg(feature = "rs")]
+    #[test]
+    fn test_build_rs_matrix() -> Result<()> {
+        use reed_solomon_erasure::matrix::Matrix;
+
+        // These examples were taken directly from the matrices created by Hadoop via RSUtil.genCauchyMatrix
+        assert_eq!(
+            gen_rs_matrix(3, 2)?,
+            Matrix::new_with_data(vec![
+                vec![1, 0, 0,],
+                vec![0, 1, 0,],
+                vec![0, 0, 1,],
+                vec![244, 142, 1,],
+                vec![71, 167, 122,],
+            ]),
+        );
+
+        assert_eq!(
+            gen_rs_matrix(6, 3)?,
+            Matrix::new_with_data(vec![
+                vec![1, 0, 0, 0, 0, 0,],
+                vec![0, 1, 0, 0, 0, 0,],
+                vec![0, 0, 1, 0, 0, 0,],
+                vec![0, 0, 0, 1, 0, 0,],
+                vec![0, 0, 0, 0, 1, 0,],
+                vec![0, 0, 0, 0, 0, 1,],
+                vec![122, 186, 71, 167, 142, 244,],
+                vec![186, 122, 167, 71, 244, 142,],
+                vec![173, 157, 221, 152, 61, 170,],
+            ]),
+        );
+
+        assert_eq!(
+            gen_rs_matrix(10, 4)?,
+            Matrix::new_with_data(vec![
+                vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 0,],
+                vec![0, 1, 0, 0, 0, 0, 0, 0, 0, 0,],
+                vec![0, 0, 1, 0, 0, 0, 0, 0, 0, 0,],
+                vec![0, 0, 0, 1, 0, 0, 0, 0, 0, 0,],
+                vec![0, 0, 0, 0, 1, 0, 0, 0, 0, 0,],
+                vec![0, 0, 0, 0, 0, 1, 0, 0, 0, 0,],
+                vec![0, 0, 0, 0, 0, 0, 1, 0, 0, 0,],
+                vec![0, 0, 0, 0, 0, 0, 0, 1, 0, 0,],
+                vec![0, 0, 0, 0, 0, 0, 0, 0, 1, 0,],
+                vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 1,],
+                vec![221, 152, 173, 157, 93, 150, 61, 170, 142, 244,],
+                vec![152, 221, 157, 173, 150, 93, 170, 61, 244, 142,],
+                vec![61, 170, 93, 150, 173, 157, 221, 152, 71, 167,],
+                vec![170, 61, 150, 93, 157, 173, 152, 221, 167, 71,],
+            ]),
+        );
+        Ok(())
+    }
+}

--- a/rust/src/hdfs/mod.rs
+++ b/rust/src/hdfs/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod connection;
 pub(crate) mod datanode;
+pub(crate) mod ec;
 pub(crate) mod protocol;
 pub(crate) mod proxy;

--- a/rust/tests/common/ec.rs
+++ b/rust/tests/common/ec.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, Bytes};
 use std::collections::HashSet;
 use std::io::{self, BufWriter, Write};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use tempfile::NamedTempFile;
 use which::which;
 
@@ -32,6 +32,8 @@ fn create_file(url: &str, path: &str, size: usize) -> io::Result<()> {
             file.path().to_str().unwrap(),
             &format!("{}{}", url, path),
         ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .unwrap();
     assert!(cmd.wait().unwrap().success());

--- a/rust/tests/common/ec.rs
+++ b/rust/tests/common/ec.rs
@@ -6,7 +6,7 @@ use tempfile::NamedTempFile;
 use which::which;
 
 use crate::common::minidfs::{DfsFeatures, MiniDfs};
-// use hdfs_native::test::{EcFaultInjection, EC_FAULT_INJECTOR};
+use hdfs_native::test::{EcFaultInjection, EC_FAULT_INJECTOR};
 use hdfs_native::{client::Client, Result};
 
 fn create_file(url: &str, path: &str, size: usize) -> io::Result<()> {
@@ -55,43 +55,47 @@ async fn test_erasure_coded_read() -> Result<()> {
     let dfs = MiniDfs::with_features(&HashSet::from([DfsFeatures::EC, DfsFeatures::SECURITY]));
     let client = Client::new(&dfs.url)?;
 
-    // Try a variety of sizes to catch any possible edge cases
-    let sizes_to_test = [
-        16usize,             // Small
-        1024 * 1024,         // One cell
-        1024 * 1024 - 4,     // Just smaller than one cell
-        1024 * 1024 + 4,     // Just bigger than one cell
-        1024 * 1024 * 3 * 5, // Five "rows" of cells
-        1024 * 1024 * 3 * 5 - 4,
-        1024 * 1024 * 3 * 5 + 4,
-        128 * 1024 * 1024,
-        128 * 1024 * 1024 - 4,
-        120 * 1024 * 1024 + 4,
-    ];
+    // Test each of Hadoop's built-in RS policies
+    for (data, parity) in [(3usize, 2usize), (6, 3), (10, 4)] {
+        let file = format!("/ec-{}-{}/testfile", data, parity);
 
-    for file_size in sizes_to_test {
-        create_file(&dfs.url, "/ec/testfile", file_size)?;
+        // Try a variety of sizes to catch any possible edge cases
+        let sizes_to_test = [
+            16usize,                // Small
+            1024 * 1024,            // One cell
+            1024 * 1024 - 4,        // Just smaller than one cell
+            1024 * 1024 + 4,        // Just bigger than one cell
+            1024 * 1024 * data * 5, // Five "rows" of cells
+            1024 * 1024 * data * 5 - 4,
+            1024 * 1024 * data * 5 + 4,
+            128 * 1024 * 1024,
+            128 * 1024 * 1024 - 4,
+            128 * 1024 * 1024 + 4,
+        ];
 
-        let reader = client.read("/ec/testfile").await?;
-        assert_eq!(reader.file_length(), file_size);
+        for file_size in sizes_to_test {
+            create_file(&dfs.url, &file, file_size)?;
 
-        // Add this back once decoding is figurd out
-        // for faults in 0..3 {
-        //     let _ = EC_FAULT_INJECTOR.lock().unwrap().insert(EcFaultInjection {
-        //         fail_blocks: (0..faults).into_iter().collect(),
-        //     });
-        let data = reader.read_range(0, reader.file_length()).await?;
-        verify_read(data, file_size);
-        // }
+            let reader = client.read(&file).await?;
+            assert_eq!(reader.file_length(), file_size);
 
-        // let _ = EC_FAULT_INJECTOR.lock().unwrap().insert(EcFaultInjection {
-        //     fail_blocks: vec![0, 1, 2],
-        // });
+            for faults in 0..parity {
+                let _ = EC_FAULT_INJECTOR.lock().unwrap().insert(EcFaultInjection {
+                    fail_blocks: (0..faults).into_iter().collect(),
+                });
+                let data = reader.read_range(0, reader.file_length()).await?;
+                verify_read(data, file_size);
+            }
 
-        // assert!(reader.read_range(0, reader.file_length()).await.is_err());
+            // Fail more than the number of parity shards, read should fail
+            let _ = EC_FAULT_INJECTOR.lock().unwrap().insert(EcFaultInjection {
+                fail_blocks: (0..=parity).into_iter().collect(),
+            });
+
+            assert!(reader.read_range(0, reader.file_length()).await.is_err());
+        }
+
+        assert!(client.delete(&file, false).await?);
     }
-
-    assert!(client.delete("/ec/testfile", false).await?);
-
     Ok(())
 }

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -6,7 +6,7 @@ use hdfs_native::client::WriteOptions;
 use hdfs_native::{client::Client, Result};
 use std::collections::HashSet;
 use std::io::{BufWriter, Write};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use tempfile::NamedTempFile;
 use which::which;
 #[cfg(feature = "object_store")]
@@ -41,6 +41,8 @@ fn setup(features: &HashSet<DfsFeatures>) -> MiniDfs {
             file.path().to_str().unwrap(),
             &format!("{}/testfile", dfs.url),
         ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .unwrap();
     assert!(cmd.wait().unwrap().success());


### PR DESCRIPTION
Resolves #2

Caveat: relies on forked https://github.com/rust-rse/reed-solomon-erasure. If https://github.com/rust-rse/reed-solomon-erasure/pull/108 gets merged we can support this in any downstream Rust builds. Currently this will only work for the Python build that relies on the fork.