### PR TITLE
Use serial_test instead of requring test-threads=1

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -109,4 +109,4 @@ jobs:
           echo "$GITHUB_WORKSPACE/hadoop-3.3.6/bin" >> $GITHUB_PATH
 
       - name: Run tests
-        run: cargo test --features kerberos,token,object_store,integration-test,rs -- --test-threads=1
+        run: cargo test --features kerberos,token,object_store,integration-test,rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.8",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +497,7 @@ dependencies = [
  "protobuf-src",
  "reed-solomon-erasure",
  "roxmltree",
+ "serial_test",
  "socket2 0.5.4",
  "tempfile",
  "thiserror",
@@ -1458,6 +1472,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ cargo build --features token,kerberos
     ```
 
 ## Running tests
-The tests are mostly integration tests that utilize a small Java application in `rust/mindifs/` that runs a custom `MiniDFSCluster`. To run the tests, you need to have Java, Maven, Hadoop binaries, and Kerberos tools available and on your path. Any Java version between 8 and 17 should work. Because they rely on this externally running process, only one test can run at a time. To run the tests:
+The tests are mostly integration tests that utilize a small Java application in `rust/mindifs/` that runs a custom `MiniDFSCluster`. To run the tests, you need to have Java, Maven, Hadoop binaries, and Kerberos tools available and on your path. Any Java version between 8 and 17 should work.
 
 ```bash
-cargo test -p hdfs-native --features token,kerberos,rs,intergation-test -- --test-threads=1
+cargo test -p hdfs-native --features token,kerberos,rs,intergation-test
 ```
 
 ### Python tests

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,6 +40,7 @@ protobuf-src = { version = "1.1", optional = true }
 
 [dev-dependencies]
 env_logger = "0.10"
+serial_test = "2.0.0"
 tempfile = "3"
 which = "4"
 

--- a/rust/src/minidfs.rs
+++ b/rust/src/minidfs.rs
@@ -78,6 +78,10 @@ impl MiniDfs {
             }
             panic!();
         }
+
+        // Make sure this doesn't care over from a token test to a non-token test
+        env::remove_var("HADOOP_TOKEN_FILE_LOCATION");
+
         if features.contains(&DfsFeatures::SECURITY) {
             let krb_conf = output.next().unwrap().unwrap();
             let kdestroy_exec = which("kdestroy").expect("Failed to find kdestroy executable");

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -1,5 +1,3 @@
-pub(crate) mod ec;
-
 use bytes::{BufMut, BytesMut};
 use hdfs_native::client::WriteOptions;
 use hdfs_native::{client::Client, Result};

--- a/rust/tests/test_ec.rs
+++ b/rust/tests/test_ec.rs
@@ -1,4 +1,5 @@
 use bytes::{Buf, Bytes};
+use serial_test::serial;
 use std::collections::HashSet;
 use std::io::{self, BufWriter, Write};
 use std::process::{Command, Stdio};
@@ -51,6 +52,8 @@ fn verify_read(mut data: Bytes, size: usize) {
 }
 
 #[tokio::test]
+#[serial]
+#[cfg(all(feature = "kerberos", feature = "rs"))]
 async fn test_erasure_coded_read() -> Result<()> {
     let _ = env_logger::builder().is_test(true).try_init();
 

--- a/rust/tests/test_integration.rs
+++ b/rust/tests/test_integration.rs
@@ -4,14 +4,17 @@ mod common;
 mod test {
     use crate::common::test_with_features;
     use hdfs_native::minidfs::DfsFeatures;
+    use serial_test::serial;
     use std::collections::HashSet;
 
     #[tokio::test]
+    #[serial]
     async fn test_basic() {
         test_with_features(&HashSet::new()).await.unwrap();
     }
 
     #[tokio::test]
+    #[serial]
     #[cfg(feature = "kerberos")]
     async fn test_security_kerberos() {
         test_with_features(&HashSet::from([DfsFeatures::SECURITY]))
@@ -20,6 +23,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[serial]
     #[cfg(feature = "token")]
     async fn test_security_token() {
         test_with_features(&HashSet::from([DfsFeatures::SECURITY, DfsFeatures::TOKEN]))
@@ -29,6 +33,7 @@ mod test {
 
     #[tokio::test]
     #[ignore]
+    #[serial]
     #[cfg(feature = "token")]
     async fn test_privacy_token() {
         test_with_features(&HashSet::from([
@@ -41,6 +46,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[serial]
     #[cfg(feature = "kerberos")]
     async fn test_privacy_kerberos() {
         test_with_features(&HashSet::from([
@@ -52,6 +58,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_basic_ha() {
         test_with_features(&HashSet::from([DfsFeatures::HA]))
             .await
@@ -59,6 +66,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[serial]
     #[cfg(feature = "kerberos")]
     async fn test_security_privacy_ha() {
         test_with_features(&HashSet::from([
@@ -71,6 +79,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[serial]
     #[cfg(feature = "token")]
     async fn test_security_token_ha() {
         test_with_features(&HashSet::from([


### PR DESCRIPTION
Came across the `serial_test` crate, which is a lot cleaner of a method for running the tests one by one than requiring the use of `--test-threads=1`