### PR TITLE
Fix edge case of reading at the start of a block

### DIFF
--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -114,9 +114,9 @@ impl FileReader {
             .iter()
             .flat_map(|block| {
                 let block_file_start = block.offset as usize;
-                let block_file_end = block_file_start + block.b.num_bytes.unwrap() as usize;
+                let block_file_end = block_file_start + block.b.num_bytes() as usize;
 
-                if block_file_start <= (offset + len) && block_file_end > offset {
+                if block_file_start < (offset + len) && block_file_end > offset {
                     // We need to read this block
                     let block_start = offset - usize::min(offset, block_file_start);
                     let block_end = usize::min(offset + len, block_file_end) - block_file_start;


### PR DESCRIPTION
Added a test case to see if there was an underlying bug based on the test failure in https://github.com/Kimahriman/hdfs-native/pull/28. Didn't find the same issue but uncovered a separate bug