### PR TITLE
Stream reading support

### DIFF
--- a/rust/src/hdfs/datanode.rs
+++ b/rust/src/hdfs/datanode.rs
@@ -148,14 +148,9 @@ impl StripedBlockStream {
     }
 
     /// Hacky "stream" of a single value to match replicated behavior
+    /// TODO: Stream the results based on rows of cells?
     fn into_stream(self) -> impl Stream<Item = Result<Bytes>> {
-        stream::unfold(Some(self), |state| async move {
-            if let Some(this) = state {
-                Some((this.read_striped().await, None))
-            } else {
-                None
-            }
-        })
+        stream::once(async move { self.read_striped().await })
     }
 
     /// Erasure coded data is stored in "cells" that are striped across Data Nodes.


### PR DESCRIPTION
Resolves #33 

Exposes a new FileReader method `read_range_stream` that returns a `Stream<Result<Bytes>>`. This lets you load large chunks (or all) of a file in chunks without having to load the whole thing into memory at once.

Existing read functions were updated to just work of this new method as a base, and are simply helper methods to get a full single buffer of data.

The object store `get` and `copy` methods were updated to use this new streaming method.