### PR TITLE
ignore failure if `msync` not found, to support older hdfs versions

### DIFF
--- a/rust/src/hdfs/proxy.rs
+++ b/rust/src/hdfs/proxy.rs
@@ -117,7 +117,8 @@ impl NameServiceProxy {
                 .map(|_| ())
                 .or_else(|err| match err {
                     HdfsError::RPCError(class, _)
-                        if class == "java.lang.UnsupportedOperationException" =>
+                        if class == "java.lang.UnsupportedOperationException"
+                            || class == "org.apache.hadoop.ipc.RpcNoSuchMethodException" =>
                     {
                         Ok(())
                     }


### PR DESCRIPTION
For #54 