### PR TITLE
Create with overwrite creates file if it doesn't exist

### DIFF
--- a/crates/hdfs-native/src/client.rs
+++ b/crates/hdfs-native/src/client.rs
@@ -45,6 +45,39 @@ impl Default for WriteOptions {
     }
 }
 
+impl AsRef<WriteOptions> for WriteOptions {
+    fn as_ref(&self) -> &WriteOptions {
+        self
+    }
+}
+
+impl WriteOptions {
+    pub fn block_size(mut self, block_size: u64) -> Self {
+        self.block_size = Some(block_size);
+        self
+    }
+
+    pub fn replication(mut self, replication: u32) -> Self {
+        self.replication = Some(replication);
+        self
+    }
+
+    pub fn permission(mut self, permission: u32) -> Self {
+        self.permission = permission;
+        self
+    }
+
+    pub fn overwrite(mut self, overwrite: bool) -> Self {
+        self.overwrite = overwrite;
+        self
+    }
+
+    pub fn create_parent(mut self, create_parent: bool) -> Self {
+        self.create_parent = create_parent;
+        self
+    }
+}
+
 #[derive(Debug, Clone)]
 struct MountLink {
     viewfs_path: PathBuf,
@@ -256,7 +289,13 @@ impl Client {
 
     /// Opens a new file for writing. See [WriteOptions] for options and behavior for different
     /// scenarios.
-    pub async fn create(&self, src: &str, write_options: WriteOptions) -> Result<FileWriter> {
+    pub async fn create(
+        &self,
+        src: &str,
+        write_options: impl AsRef<WriteOptions>,
+    ) -> Result<FileWriter> {
+        let write_options = write_options.as_ref();
+
         let (link, resolved_path) = self.mount_table.resolve(src);
         let server_defaults = link.protocol.get_server_defaults().await?.server_defaults;
 

--- a/crates/hdfs-native/src/hdfs/protocol.rs
+++ b/crates/hdfs-native/src/hdfs/protocol.rs
@@ -108,6 +108,10 @@ impl NamenodeProtocol {
         block_size: u64,
     ) -> Result<hdfs::CreateResponseProto> {
         let masked = hdfs::FsPermissionProto { perm: permission };
+        let mut create_flag = hdfs::CreateFlagProto::Create as u32;
+        if overwrite {
+            create_flag |= hdfs::CreateFlagProto::Overwrite as u32;
+        }
 
         let message = hdfs::CreateRequestProto {
             src: src.to_string(),
@@ -116,11 +120,7 @@ impl NamenodeProtocol {
             create_parent,
             replication,
             block_size,
-            create_flag: if overwrite {
-                hdfs::CreateFlagProto::Overwrite
-            } else {
-                hdfs::CreateFlagProto::Create
-            } as u32,
+            create_flag,
             ..Default::default()
         };
 

--- a/crates/hdfs-native/tests/test_integration.rs
+++ b/crates/hdfs-native/tests/test_integration.rs
@@ -221,23 +221,20 @@ mod test {
     }
 
     async fn test_create(client: &Client) -> Result<()> {
-        let mut write_options = WriteOptions::default();
+        let write_options = WriteOptions::default().overwrite(true);
 
         // Create an empty file
-        let mut writer = client.create("/newfile", write_options.clone()).await?;
+        let mut writer = client.create("/newfile", &write_options).await?;
 
         writer.close().await?;
 
         assert_eq!(client.get_file_info("/newfile").await?.length, 0);
 
-        // Overwrite now
-        write_options.overwrite = true;
-
         // Check a small files, a file that is exactly one block, and a file slightly bigger than a block
         for size_to_check in [16i32, 128 * 1024 * 1024, 130 * 1024 * 1024] {
             let ints_to_write = size_to_check / 4;
 
-            let mut writer = client.create("/newfile", write_options.clone()).await?;
+            let mut writer = client.create("/newfile", &write_options).await?;
 
             let mut data = BytesMut::with_capacity(size_to_check as usize);
             for i in 0..ints_to_write {
@@ -323,17 +320,17 @@ mod test {
         let write_options = WriteOptions::default();
         client.mkdirs("/dir/nested", 0o755, true).await?;
         client
-            .create("/dir/file1", write_options.clone())
+            .create("/dir/file1", &write_options)
             .await?
             .close()
             .await?;
         client
-            .create("/dir/nested/file2", write_options.clone())
+            .create("/dir/nested/file2", &write_options)
             .await?
             .close()
             .await?;
         client
-            .create("/dir/nested/file3", write_options.clone())
+            .create("/dir/nested/file3", &write_options)
             .await?
             .close()
             .await?;


### PR DESCRIPTION
Make create with overwrite a little more user friendly and allow creating a file if it doesn't already exist. This is what other file systems typical behavior would be.

Also makes WriteOptions a little more user friendly with helper functions that can be chained, and `create` takes an `impl AsRef<WriteOptions>` now so a borrowed value can be passed in.