### PR TITLE
Only need benchmark feature to run benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,7 @@ export CLASSPATH=$(hadoop classpath)
 
 then you can run the benchmarks with
 ```bash
-cargo bench -p hdfs-native --features benchmark,integration-test
+cargo bench -p hdfs-native --features benchmark
 ```
+
+The `benchmark` feature is required to expose `minidfs` and the internal erasure coding functions to benchmark.

--- a/crates/hdfs-native/build.rs
+++ b/crates/hdfs-native/build.rs
@@ -20,7 +20,7 @@ fn main() -> Result<()> {
         )?;
     }
 
-    #[cfg(feature = "integration-test")]
+    #[cfg(any(feature = "integration-test", feature = "benchmark"))]
     {
         // Copy the minidfs src to the build directory so we can run it in downstream tests
         let status = std::process::Command::new("cp")


### PR DESCRIPTION
Follow up to https://github.com/Kimahriman/hdfs-native/pull/75, remove the need for `integration-test` feature for running benchmarks