### PR TITLE
Support DataNode connection reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.0",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.46",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,9 +301,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crc"
-version = "3.0.1"
+version = "3.1.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+checksum = "a02c6ee9f6aa3049d991777025b73fbecc46696f3b3946c4eae4a0fbedec65ab"
 dependencies = [
  "crc-catalog",
 ]
@@ -456,7 +479,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f38e500596a428817fd4fd8a9a21da32f4edb3250e87886039670b12ea02f5d"
 dependencies = [
- "bindgen",
+ "bindgen 0.64.0",
  "cc",
  "lazy_static",
  "libc",
@@ -658,6 +681,7 @@ dependencies = [
  "libgssapi",
  "log",
  "num-traits",
+ "once_cell",
  "prost",
  "prost-build",
  "prost-types",
@@ -933,9 +957,9 @@ checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libgssapi"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcfb7f77cbefc242a46ea667491c4f1129712f563cd368623d3f1b261a90e5f"
+checksum = "c22f0430969e524b2177498ca3eeed48faca6f6c80f1b098d27ecbec84222f3a"
 dependencies = [
  "bitflags 2.4.1",
  "bytes",
@@ -945,11 +969,12 @@ dependencies = [
 
 [[package]]
 name = "libgssapi-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdcdd31923aa6280d41ff2636fd93a18cc60fe25983b24887d1a8d24478cbfb"
+checksum = "b57d9a71c774ec53b1b9119dbbcc589b5209831f0ddc0ff4210640051f545372"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.4",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1178,6 +1203,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plotters"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crc"
-version = "3.1.0-beta.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a02c6ee9f6aa3049d991777025b73fbecc46696f3b3946c4eae4a0fbedec65ab"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
  "crc-catalog",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ version = "0.7.0"
 dependencies = [
  "base64",
  "bytes",
+ "chrono",
  "crc",
  "criterion",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ resolver = "2"
 bytes = "1"
 futures = "0.3"
 tokio = "1"
+
+[profile.bench]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 
 [workspace.dependencies]
 bytes = "1"
+chrono = "0.4"
 futures = "0.3"
 tokio = "1"
 

--- a/crates/hdfs-native-object-store/Cargo.toml
+++ b/crates/hdfs-native-object-store/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 [dependencies]
 async-trait = { version = "0.1" }
 bytes = { workspace = true }
-chrono = { version = "0.4" }
+chrono = { workspace = true }
 futures = { workspace = true }
 hdfs-native = { path = "../hdfs-native", version = "0.7" }
 object_store = { version = "0.9", features = ["cloud"] }

--- a/crates/hdfs-native/Cargo.toml
+++ b/crates/hdfs-native/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 [dependencies]
 base64 = "0.21"
 bytes = { workspace = true }
+chrono = { workspace = true }
 crc = "3.1.0-beta.1"
 futures = { workspace = true }
 g2p = "1"

--- a/crates/hdfs-native/Cargo.toml
+++ b/crates/hdfs-native/Cargo.toml
@@ -18,9 +18,10 @@ futures = { workspace = true }
 g2p = "1"
 gsasl-sys = { version = "0.2", default-features = false, optional = true }
 libc = "0.2"
-libgssapi = { version = "0.6", default-features = false, optional = true }
+libgssapi = { version = "0.7", default-features = false, optional = true }
 log = "0.4"
 num-traits = "0.2"
+once_cell = "1.19.0"
 prost = "0.12"
 prost-types = "0.12"
 roxmltree = "0.18"

--- a/crates/hdfs-native/src/hdfs/block_reader.rs
+++ b/crates/hdfs-native/src/hdfs/block_reader.rs
@@ -394,8 +394,8 @@ impl StripedBlockStream {
             &datanode_url,
             block,
             token.clone(),
-            self.offset as u64,
-            self.len as u64,
+            offset as u64,
+            len as u64,
         )
         .await?;
 
@@ -427,6 +427,8 @@ impl StripedBlockStream {
 
         // There should be one last empty packet after we are done
         connection.read_packet().await?;
+        connection.send_read_success().await?;
+        DATANODE_CACHE.release(connection);
 
         Ok(())
     }

--- a/crates/hdfs-native/src/hdfs/connection.rs
+++ b/crates/hdfs-native/src/hdfs/connection.rs
@@ -519,7 +519,7 @@ pub(crate) struct DatanodeConnection {
 }
 
 impl DatanodeConnection {
-    async fn connect(url: &str) -> Result<Self> {
+    pub(crate) async fn connect(url: &str) -> Result<Self> {
         let stream = BufStream::new(connect(url).await?);
 
         let conn = DatanodeConnection {
@@ -700,23 +700,14 @@ impl DatanodeConnectionCache {
         }
     }
 
-    pub(crate) async fn get(&self, url: &str) -> Result<DatanodeConnection> {
-        let conn = self
-            .cache
+    pub(crate) fn get(&self, url: &str) -> Option<DatanodeConnection> {
+        self.cache
             .lock()
             .unwrap()
             .get_mut(url)
             .iter_mut()
             .flat_map(|conns| conns.pop_front())
-            .next();
-
-        if let Some(conn) = conn {
-            debug!("Returning cached connection");
-            Ok(conn)
-        } else {
-            debug!("Creating new connection");
-            DatanodeConnection::connect(url).await
-        }
+            .next()
     }
 
     pub(crate) fn release(&self, conn: DatanodeConnection) {

--- a/crates/hdfs-native/src/hdfs/connection.rs
+++ b/crates/hdfs-native/src/hdfs/connection.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::default::Default;
 use std::io::ErrorKind;
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -8,6 +8,7 @@ use std::sync::Mutex;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crc::{Crc, CRC_32_CKSUM, CRC_32_ISCSI};
 use log::{debug, warn};
+use once_cell::sync::Lazy;
 use prost::Message;
 use socket2::SockRef;
 use tokio::io::BufStream;
@@ -35,6 +36,9 @@ const MAX_PACKET_HEADER_SIZE: usize = 33;
 
 const CRC32: Crc<u32> = Crc::<u32>::new(&CRC_32_CKSUM);
 const CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
+
+pub(crate) static DATANODE_CACHE: Lazy<DatanodeConnectionCache> =
+    Lazy::new(DatanodeConnectionCache::new);
 
 // Connect to a remote host and return a TcpStream with standard options we want
 async fn connect(addr: &str) -> Result<TcpStream> {
@@ -511,20 +515,26 @@ impl Packet {
 pub(crate) struct DatanodeConnection {
     client_name: String,
     stream: BufStream<TcpStream>,
+    url: String,
 }
 
 impl DatanodeConnection {
-    pub(crate) async fn connect(url: &str) -> Result<Self> {
+    async fn connect(url: &str) -> Result<Self> {
         let stream = BufStream::new(connect(url).await?);
 
         let conn = DatanodeConnection {
             client_name: Uuid::new_v4().to_string(),
             stream,
+            url: url.to_string(),
         };
         Ok(conn)
     }
 
-    pub(crate) async fn send(&mut self, op: Op, message: &impl Message) -> Result<()> {
+    pub(crate) async fn send(
+        &mut self,
+        op: Op,
+        message: &impl Message,
+    ) -> Result<hdfs::BlockOpResponseProto> {
         self.stream
             .write_all(&DATA_TRANSFER_VERSION.to_be_bytes())
             .await?;
@@ -533,7 +543,16 @@ impl DatanodeConnection {
             .write_all(&message.encode_length_delimited_to_vec())
             .await?;
         self.stream.flush().await?;
-        Ok(())
+
+        let buf = self.stream.fill_buf().await?;
+        let msg_length = prost::decode_length_delimiter(buf)?;
+        let total_size = msg_length + prost::length_delimiter_len(msg_length);
+
+        let mut response_buf = BytesMut::zeroed(total_size);
+        self.stream.read_exact(&mut response_buf).await?;
+
+        let response = hdfs::BlockOpResponseProto::decode_length_delimited(response_buf.freeze())?;
+        Ok(response)
     }
 
     pub(crate) fn build_header(
@@ -551,18 +570,6 @@ impl DatanodeConnection {
             base_header,
             client_name: self.client_name.clone(),
         }
-    }
-
-    pub(crate) async fn read_block_op_response(&mut self) -> Result<hdfs::BlockOpResponseProto> {
-        let buf = self.stream.fill_buf().await?;
-        let msg_length = prost::decode_length_delimiter(buf)?;
-        let total_size = msg_length + prost::length_delimiter_len(msg_length);
-
-        let mut response_buf = BytesMut::zeroed(total_size);
-        self.stream.read_exact(&mut response_buf).await?;
-
-        let response = hdfs::BlockOpResponseProto::decode_length_delimited(response_buf.freeze())?;
-        Ok(response)
     }
 
     pub(crate) async fn read_packet(&mut self) -> Result<Packet> {
@@ -596,7 +603,6 @@ impl DatanodeConnection {
             .write_all(&client_read_status.encode_length_delimited_to_vec())
             .await?;
         self.stream.flush().await?;
-        self.stream.shutdown().await?;
 
         Ok(())
     }
@@ -606,6 +612,7 @@ impl DatanodeConnection {
         let reader = DatanodeReader {
             client_name: self.client_name.clone(),
             reader: BufReader::new(reader),
+            url: self.url,
         };
         let writer = DatanodeWriter {
             client_name: self.client_name,
@@ -622,6 +629,7 @@ impl DatanodeConnection {
         Self {
             client_name: reader.client_name,
             stream,
+            url: reader.url,
         }
     }
 }
@@ -631,6 +639,7 @@ impl DatanodeConnection {
 pub(crate) struct DatanodeReader {
     client_name: String,
     reader: BufReader<OwnedReadHalf>,
+    url: String,
 }
 
 impl DatanodeReader {
@@ -677,6 +686,42 @@ impl DatanodeWriter {
         self.writer.flush().await?;
 
         Ok(())
+    }
+}
+
+pub(crate) struct DatanodeConnectionCache {
+    cache: Mutex<HashMap<String, VecDeque<DatanodeConnection>>>,
+}
+
+impl DatanodeConnectionCache {
+    fn new() -> Self {
+        Self {
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) async fn get(&self, url: &str) -> Result<DatanodeConnection> {
+        let conn = self
+            .cache
+            .lock()
+            .unwrap()
+            .get_mut(url)
+            .iter_mut()
+            .flat_map(|conns| conns.pop_front())
+            .next();
+
+        if let Some(conn) = conn {
+            debug!("Returning cached connection");
+            Ok(conn)
+        } else {
+            debug!("Creating new connection");
+            DatanodeConnection::connect(url).await
+        }
+    }
+
+    pub(crate) fn release(&self, conn: DatanodeConnection) {
+        let mut cache = self.cache.lock().unwrap();
+        cache.entry(conn.url.clone()).or_default().push_back(conn);
     }
 }
 

--- a/crates/hdfs-native/src/security/gssapi.rs
+++ b/crates/hdfs-native/src/security/gssapi.rs
@@ -53,7 +53,7 @@ impl GssapiSession {
         let principal = cred.name()?.to_string();
 
         let state = GssapiState::Pending(ClientCtx::new(
-            cred,
+            Some(cred),
             target,
             // Allow all flags. Setting them does not mean the final context will provide
             // them, so this should not be an issue.


### PR DESCRIPTION
Resolves #79 

Adds a static DataNode connection cache with a three second expiry, the default the Hadoop client uses. Connections are only purged from the cache when a connection is retrieved from the cache, and we will try up to three cached connections before falling back to creating a new connection. This should help speed up multiple reads to the same file/DataNode in fast succession.