### PR TITLE
feat: Configure optional `kerberos` feature for Python package

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -27,8 +27,11 @@ name = "hdfs_native._internal"
 [dependencies]
 bytes = "1.4" 
 env_logger = "0.10"
-hdfs-native = { path = "../crates/hdfs-native", features=["kerberos"] }
+hdfs-native = { path = "../crates/hdfs-native" }
 log = "0.4"
 pyo3 = { version = "0.20", features = ["extension-module", "abi3", "abi3-py38"] }
 thiserror = "1.0.43"
 tokio = { version = "1.28", features = ["rt-multi-thread"] }
+
+[features]
+kerberos = ["hdfs-native/kerberos"]


### PR DESCRIPTION
To make Kerberos an optional feature for python package, and make it consistent with both hdfs-native and hdfs-native-object-store:

- Remove the explicit "kerberos" feature from the `hdfs-native` dependency declaration in Cargo.toml.
- Add a new feature named "kerberos", allowing the "kerberos" feature to be optionally enabled for the Python package.
