### PR TITLE
Conslidate Python deps with workspace and update CI to deploy Kerberos feature

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path python/Cargo.toml
+          args: --release --out dist --find-interpreter --manifest-path python/Cargo.toml --features kerberos
           sccache: 'true'
           container: quay.io/pypa/manylinux2014_${{ matrix.target }}:latest
           docker-options: -e LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64 -e LLVM_CONFIG_PATH=/opt/rh/llvm-toolset-7.0/root/usr/bin/llvm-config
@@ -61,7 +61,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path python/Cargo.toml
+          args: --release --out dist --find-interpreter --manifest-path python/Cargo.toml --features kerberos
           sccache: 'true'
         env:
           BINDGEN_EXTRA_CLANG_ARGS: "-I/usr/local/include"
@@ -80,7 +80,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
-          args: --out dist --manifest-path python/Cargo.toml
+          args: --out dist --manifest-path python/Cargo.toml --features kerberos
       - name: Upload sdist
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -68,6 +68,7 @@ jobs:
           sccache: 'true'
           container: 'off'
           working-directory: ./python
+          args: --features kerberos
       
       - name: Install dev dependencies and run tests
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.1.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +448,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -743,6 +772,7 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 name = "hdfs-native"
 version = "0.8.0"
 dependencies = [
+ "aes",
  "base64",
  "bytes",
  "cbc",
@@ -750,6 +780,7 @@ dependencies = [
  "cipher",
  "crc",
  "criterion",
+ "ctr",
  "des",
  "env_logger",
  "fs-hdfs3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ resolver = "2"
 bytes = "1"
 chrono = "0.4"
 futures = "0.3"
+log = "0.4"
+thiserror = "1"
 tokio = "1"
 
 [profile.bench]

--- a/crates/hdfs-native/Cargo.toml
+++ b/crates/hdfs-native/Cargo.toml
@@ -11,12 +11,14 @@ readme = "../../README.md"
 license = "Apache-2.0"
 
 [dependencies]
+aes = "0.8"
 base64 = "0.21"
 bytes = { workspace = true }
 cbc = "0.1"
 chrono = { workspace = true }
 cipher = "0.4"
 crc = "3.1.0-beta.1"
+ctr = "0.9"
 des = "0.8"
 futures = { workspace = true }
 g2p = "1"
@@ -24,7 +26,7 @@ hex = "0.4"
 hmac = "0.12"
 libc = "0.2"
 libgssapi = { version = "0.7", default-features = false, optional = true }
-log = "0.4"
+log = { workspace = true }
 md-5 = "0.10"
 num-traits = "0.2"
 once_cell = "1"
@@ -34,7 +36,7 @@ rand = "0.8"
 regex = "1"
 roxmltree = "0.18"
 socket2 = "0.5"
-thiserror = "1"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "net", "io-util", "macros", "sync", "time"] }
 url = "2"
 users = { version = "0.11", default-features = false }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -25,13 +25,13 @@ doc = false
 name = "hdfs_native._internal"
 
 [dependencies]
-bytes = "1.4" 
+bytes = { workspace = true } 
 env_logger = "0.10"
 hdfs-native = { path = "../crates/hdfs-native" }
 log = "0.4"
 pyo3 = { version = "0.20", features = ["extension-module", "abi3", "abi3-py38"] }
-thiserror = "1.0.43"
-tokio = { version = "1.28", features = ["rt-multi-thread"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [features]
 kerberos = ["hdfs-native/kerberos"]


### PR DESCRIPTION
After https://github.com/Kimahriman/hdfs-native/pull/91, update CI to test and deploy kerberos feature, and use workspace versions for Python cargo deps