### PR TITLE
Add support for encrypting data transfers with AES

### DIFF
--- a/crates/hdfs-native/minidfs/src/main/java/main/Main.java
+++ b/crates/hdfs-native/minidfs/src/main/java/main/Main.java
@@ -57,7 +57,10 @@ public class Main {
                 conf.set(HADOOP_RPC_PROTECTION, "privacy");
                 conf.set(DFS_DATA_TRANSFER_PROTECTION_KEY, "privacy");
                 if (flags.contains("data_transfer_encryption")) {
+                    // Force encryption for all connections
                     conf.set(DFSConfigKeys.DFS_ENCRYPT_DATA_TRANSFER_KEY, "true");
+                }
+                if (flags.contains("aes")) {
                     conf.set(DFS_ENCRYPT_DATA_TRANSFER_CIPHER_SUITES_KEY, "AES/CTR/NoPadding");
                 }
             } else if (flags.contains("integrity")) {

--- a/crates/hdfs-native/src/hdfs/connection.rs
+++ b/crates/hdfs-native/src/hdfs/connection.rs
@@ -550,12 +550,9 @@ impl DatanodeConnection {
             .await?;
         self.writer.flush().await?;
 
-        let msg_length = self.reader.read_length_delimiter().await?;
+        let message = self.reader.read_proto().await?;
 
-        let mut response_buf = BytesMut::zeroed(msg_length);
-        self.reader.read_exact(&mut response_buf).await?;
-
-        let response = hdfs::BlockOpResponseProto::decode(response_buf.freeze())?;
+        let response = hdfs::BlockOpResponseProto::decode(message)?;
         Ok(response)
     }
 
@@ -630,12 +627,9 @@ pub(crate) struct DatanodeReader {
 
 impl DatanodeReader {
     pub(crate) async fn read_ack(&mut self) -> Result<hdfs::PipelineAckProto> {
-        let ack_length = self.reader.read_length_delimiter().await?;
+        let message = self.reader.read_proto().await?;
 
-        let mut response_buf = BytesMut::zeroed(ack_length);
-        self.reader.read_exact(&mut response_buf).await?;
-
-        let response = hdfs::PipelineAckProto::decode(response_buf.freeze())?;
+        let response = hdfs::PipelineAckProto::decode(message)?;
         Ok(response)
     }
 }

--- a/crates/hdfs-native/src/minidfs.rs
+++ b/crates/hdfs-native/src/minidfs.rs
@@ -13,6 +13,7 @@ pub enum DfsFeatures {
     Token,
     Integrity,
     Privacy,
+    AES,
     HA,
     ViewFS,
     EC,
@@ -28,6 +29,7 @@ impl DfsFeatures {
             DfsFeatures::Privacy => "privacy",
             DfsFeatures::Security => "security",
             DfsFeatures::Integrity => "integrity",
+            DfsFeatures::AES => "aes",
             DfsFeatures::Token => "token",
             DfsFeatures::RBF => "rbf",
         }

--- a/crates/hdfs-native/src/security/digest.rs
+++ b/crates/hdfs-native/src/security/digest.rs
@@ -357,6 +357,14 @@ impl DigestSaslSession {
             server: kis,
         }
     }
+
+    pub(crate) fn supports_encryption(&self) -> bool {
+        match &self.state {
+            DigestState::Stepped(ctx) => matches!(ctx.qop, Qop::AuthConf),
+            DigestState::Completed(ctx) => ctx.as_ref().is_some_and(|c| c.encryptor.is_some()),
+            _ => false,
+        }
+    }
 }
 
 impl SaslSession for DigestSaslSession {

--- a/crates/hdfs-native/tests/test_integration.rs
+++ b/crates/hdfs-native/tests/test_integration.rs
@@ -81,6 +81,18 @@ mod test {
 
     #[tokio::test]
     #[serial]
+    async fn test_aes() {
+        test_with_features(&HashSet::from([
+            DfsFeatures::Security,
+            DfsFeatures::Privacy,
+            DfsFeatures::AES,
+        ]))
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn test_basic_ha() {
         test_with_features(&HashSet::from([DfsFeatures::HA]))
             .await


### PR DESCRIPTION
Part of https://github.com/Kimahriman/hdfs-native/issues/89

Adds cipher support to data transfer connections, and supports 128, 192, and 256 bit AES encryption