### PR TITLE
 fix the error that when execute client.list_status_iter(&source_file_path, true); in windows paltform,throw file not found error because of the path separator is not '/' but '\'

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -588,11 +588,12 @@ pub(crate) struct DirListingIterator {
 
 impl DirListingIterator {
     fn new(path: String, mount_table: &Arc<MountTable>, files_only: bool) -> Self {
-        let (link, resolved_path) = mount_table.resolve(&path);
+
+        let (link, resolved_path) = mount_table.resolve(&path.replace("\\","/"));
 
         DirListingIterator {
             path,
-            resolved_path,
+            resolved_path: resolved_path.replace("\\","/"),
             link: link.clone(),
             files_only,
             partial_listing: VecDeque::new(),


### PR DESCRIPTION
 fix the error that when execute client.list_status_iter(&source_file_path, true); in windows paltform,throw file not found error because of the path separator is not '/' but '\'