### PR TITLE
Add short sleeps to make ls test deterministic

### DIFF
--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -4,9 +4,9 @@ import io
 import os
 import re
 import stat
+import time
 from datetime import datetime
 from tempfile import TemporaryDirectory
-import time
 from typing import Callable, Iterator, List, Literal, Optional, Tuple, overload
 
 import pytest

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -6,6 +6,7 @@ import re
 import stat
 from datetime import datetime
 from tempfile import TemporaryDirectory
+import time
 from typing import Callable, Iterator, List, Literal, Optional, Tuple, overload
 
 import pytest
@@ -268,9 +269,14 @@ def test_ls(client: Client):
     with client.create("/testfile1") as f:
         f.write(bytes(range(10)))
 
+    # Make sure we wait a few milliseconds so we don't get the exact same timestamp
+    time.sleep(0.01)
+
     with client.create("/testfile2") as f:
         for i in range(1024):
             f.write(i.to_bytes(4, "big"))
+
+    time.sleep(0.01)
 
     client.mkdirs("/testdir")
 


### PR DESCRIPTION
The `test_ls` for the CLI test seems flaky, and my best guess is the files and dirs are created so fast they have the same millisecond timestamp stored in HDFS, so the sorting is then non-deterministic. Just add a short sleep to try to address this