### PR TITLE
Switch RPC call for file reads

### DIFF
--- a/rust/minidfs/pom.xml
+++ b/rust/minidfs/pom.xml
@@ -7,11 +7,15 @@
   <artifactId>minidfs</artifactId>
   <version>1.0-SNAPSHOT</version>
 
+  <properties>
+    <hadoop.version>3.4.1</hadoop.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minicluster</artifactId>
-      <version>3.4.1</version>
+      <version>${hadoop.version}</version>
       <exclusions>
         <exclusion>
           <groupId>ch.qos.logback</groupId>
@@ -22,23 +26,23 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minikdc</artifactId>
-      <version>3.4.1</version>
+      <version>${hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs-rbf</artifactId>
-      <version>3.4.1</version>
+      <version>${hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs-rbf</artifactId>
-      <version>3.4.1</version>
+      <version>${hadoop.version}</version>
       <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-federation-balance</artifactId>
-      <version>3.4.1</version>
+      <version>${hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -279,34 +279,30 @@ impl Client {
     /// Opens a file reader for the file at `path`. Path should not include a scheme.
     pub async fn read(&self, path: &str) -> Result<FileReader> {
         let (link, resolved_path) = self.mount_table.resolve(path);
-        let located_info = link.protocol.get_located_file_info(&resolved_path).await?;
-        match located_info.fs {
-            Some(mut status) => {
-                let ec_schema = if let Some(ec_policy) = status.ec_policy.as_ref() {
-                    Some(resolve_ec_policy(ec_policy)?)
-                } else {
-                    None
-                };
+        // Get all block locations. Length is actually a signed value, but the proto uses an unsigned value
+        let located_info = link
+            .protocol
+            .get_block_locations(&resolved_path, 0, i64::MAX as u64)
+            .await?;
 
-                if status.file_encryption_info.is_some() {
-                    return Err(HdfsError::UnsupportedFeature("File encryption".to_string()));
-                }
-                if status.file_type() == FileType::IsDir {
-                    return Err(HdfsError::IsADirectoryError(path.to_string()));
-                }
+        if let Some(locations) = located_info.locations {
+            let ec_schema = if let Some(ec_policy) = locations.ec_policy.as_ref() {
+                Some(resolve_ec_policy(ec_policy)?)
+            } else {
+                None
+            };
 
-                if let Some(locations) = status.locations.take() {
-                    Ok(FileReader::new(
-                        Arc::clone(&link.protocol),
-                        status,
-                        locations,
-                        ec_schema,
-                    ))
-                } else {
-                    Err(HdfsError::BlocksNotFound(path.to_string()))
-                }
+            if locations.file_encryption_info.is_some() {
+                return Err(HdfsError::UnsupportedFeature("File encryption".to_string()));
             }
-            None => Err(HdfsError::FileNotFound(path.to_string())),
+
+            Ok(FileReader::new(
+                Arc::clone(&link.protocol),
+                locations,
+                ec_schema,
+            ))
+        } else {
+            Err(HdfsError::FileNotFound(path.to_string()))
         }
     }
 

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -19,7 +19,6 @@ const COMPLETE_RETRIES: u32 = 5;
 
 pub struct FileReader {
     protocol: Arc<NamenodeProtocol>,
-    status: hdfs::HdfsFileStatusProto,
     located_blocks: hdfs::LocatedBlocksProto,
     ec_schema: Option<EcSchema>,
     position: usize,
@@ -28,13 +27,11 @@ pub struct FileReader {
 impl FileReader {
     pub(crate) fn new(
         protocol: Arc<NamenodeProtocol>,
-        status: hdfs::HdfsFileStatusProto,
         located_blocks: hdfs::LocatedBlocksProto,
         ec_schema: Option<EcSchema>,
     ) -> Self {
         Self {
             protocol,
-            status,
             located_blocks,
             ec_schema,
             position: 0,
@@ -43,7 +40,7 @@ impl FileReader {
 
     /// Returns the total size of the file
     pub fn file_length(&self) -> usize {
-        self.status.length as usize
+        self.located_blocks.file_length as usize
     }
 
     /// Returns the remaining bytes left based on the current cursor position.

--- a/rust/src/hdfs/protocol.rs
+++ b/rust/src/hdfs/protocol.rs
@@ -90,15 +90,18 @@ impl NamenodeProtocol {
         self.call("getListing", message, false).await
     }
 
-    pub(crate) async fn get_located_file_info(
+    pub(crate) async fn get_block_locations(
         &self,
         src: &str,
-    ) -> Result<hdfs::GetLocatedFileInfoResponseProto> {
-        let message = hdfs::GetLocatedFileInfoRequestProto {
-            src: Some(src.to_string()),
-            need_block_token: Some(true),
+        offset: u64,
+        length: u64,
+    ) -> Result<hdfs::GetBlockLocationsResponseProto> {
+        let message = hdfs::GetBlockLocationsRequestProto {
+            src: src.to_string(),
+            offset,
+            length,
         };
-        self.call("getLocatedFileInfo", message, false).await
+        self.call("getBlockLocations", message, false).await
     }
 
     pub(crate) async fn get_server_defaults(&self) -> Result<hdfs::GetServerDefaultsResponseProto> {

--- a/rust/tests/test_integration.rs
+++ b/rust/tests/test_integration.rs
@@ -309,6 +309,10 @@ mod test {
 
         assert!(client.delete("/newfile", false).await.is_ok_and(|r| r));
 
+        client.mkdirs("/testdir", 0o755, true).await?;
+        assert!(client.read("/testdir").await.is_err());
+        client.delete("/testdir", true).await?;
+
         Ok(())
     }
 


### PR DESCRIPTION
Resolves #216 

`getLocatedFileInfo` was added in Hadoop 3.1. Simply use `getBlockLocations` instead which provides the same necessary information to be compatible with older Hadoop versions