### PR TITLE
Correct expect error string

### DIFF
--- a/rust/src/minidfs.rs
+++ b/rust/src/minidfs.rs
@@ -56,7 +56,7 @@ pub struct MiniDfs {
 
 impl MiniDfs {
     pub fn with_features(features: &HashSet<DfsFeatures>) -> Self {
-        let mvn_exec = which("mvn").expect("Failed to find java executable");
+        let mvn_exec = which("mvn").expect("Failed to find mvn executable");
 
         let mut feature_args: Vec<&str> = Vec::new();
         for feature in features.iter() {


### PR DESCRIPTION
The test failure I was seeing was due to mvn not existing, java had been there the whole time :upside_down_face: