### PR TITLE
Sleep in dedicated runtime

### DIFF
--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -298,7 +298,12 @@ impl FileWriter {
                     return Ok(());
                 }
 
-                tokio::time::sleep(Duration::from_millis(retry_delay)).await;
+                // Sleep in the provided runtime in case we are not called from a tokio runtime
+                let sleep = {
+                    let _guard = self.handle.enter();
+                    tokio::time::sleep(Duration::from_millis(retry_delay))
+                };
+                sleep.await;
 
                 retry_delay *= 2;
                 retries += 1;


### PR DESCRIPTION
Resolves #256 

This is the only sleep that isn't in a spawned task that is already guaranteed to be in a tokio runtime. Create the sleep in an enter guard to be sure it is attached to the provided runtime