### PR TITLE
Disable SASL for DataNodes if dfs.data.transfer.protection not set

### DIFF
--- a/rust/src/common/config.rs
+++ b/rust/src/common/config.rs
@@ -23,6 +23,7 @@ const DFS_CLIENT_FAILOVER_RESOLVE_NEEDED: &str = "dfs.client.failover.resolve-ne
 const DFS_CLIENT_FAILOVER_RESOLVER_USE_FQDN: &str = "dfs.client.failover.resolver.useFQDN";
 const DFS_CLIENT_FAILOVER_RANDOM_ORDER: &str = "dfs.client.failover.random.order";
 const DFS_CLIENT_FAILOVER_PROXY_PROVIDER: &str = "dfs.client.failover.proxy.provider";
+const DFS_DATA_TRANSFER_PROTECTION: &str = "dfs.data.transfer.protection";
 
 const HADOOP_SECURITY_AUTHENTICATION: &str = "hadoop.security.authentication";
 
@@ -81,6 +82,10 @@ impl Configuration {
     pub(crate) fn security_enabled(&self) -> bool {
         self.get(HADOOP_SECURITY_AUTHENTICATION)
             .is_some_and(|c| c != "simple")
+    }
+
+    pub(crate) fn data_transfer_protection_enabled(&self) -> bool {
+        self.get(DFS_DATA_TRANSFER_PROTECTION).is_some()
     }
 
     pub(crate) fn get_urls_for_nameservice(&self, nameservice: &str) -> Result<Vec<String>> {

--- a/rust/src/security/sasl.rs
+++ b/rust/src/security/sasl.rs
@@ -600,8 +600,10 @@ impl SaslDatanodeConnection {
     /// 1. If `dfs.encrypt.data.transfer` is set on the NameNode, always encrypt the session
     ///    and use an encryption key from the NameNode for the negotiation. This will happen
     ///    if `encryption_key` is defined.
-    /// 2. If there is no block token or the DataNode transfer port is privileged (<= 1024), we
-    ///    skip the SASL handshake and assume it is trusted.
+    /// 2. If there is no block token
+    ///    or the DataNode transfer port is privileged (<= 1024)
+    ///    or `dfs.data.transfer.protection` not set,
+    ///    we skip the SASL handshake and assume it is trusted.
     /// 3. Otherwise, we do a SAL handshake using the provided block token.
     ///
     /// For cases 1 and 3, we optionally negotiate a cipher to use for encryption instead of
@@ -618,6 +620,7 @@ impl SaslDatanodeConnection {
         } else if !config.security_enabled()
             || token.identifier.is_empty()
             || datanode_id.xfer_port <= 1024
+            || !config.data_transfer_protection_enabled()
         {
             return self.split(None, None);
         } else {


### PR DESCRIPTION


Fix: "All DataNodes failed" in kerberized env if dfs.data.transfer.protection not set.
Discussed in:
https://github.com/Kimahriman/hdfs-native/issues/258