### PR TITLE
Poison call map after listener failure to prevent stale inserts

### DIFF
--- a/rust/src/hdfs/connection.rs
+++ b/rust/src/hdfs/connection.rs
@@ -779,14 +779,10 @@ impl DatanodeConnectionCache {
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
-    use std::io::ErrorKind;
-    use std::sync::{Arc, Mutex};
 
-    use bytes::Bytes;
     use prost::Message;
-    use tokio::sync::oneshot;
 
-    use crate::{HdfsError, Result, hdfs::connection::MAX_PACKET_HEADER_SIZE, proto::hdfs};
+    use crate::{hdfs::connection::MAX_PACKET_HEADER_SIZE, proto::hdfs};
 
     use super::AlignmentContext;
 
@@ -840,63 +836,5 @@ mod test {
         assert_eq!(router_state.len(), 2);
         assert_eq!(*router_state.get("ns-1").unwrap(), 5);
         assert_eq!(*router_state.get("ns-2").unwrap(), 7);
-    }
-
-    type CallResult = oneshot::Sender<Result<Bytes>>;
-
-    #[test]
-    fn test_call_map_partial_drain_then_poison() {
-        // Simulates: listener processes some responses, then dies mid-stream
-        let call_map: Arc<Mutex<Option<HashMap<i32, CallResult>>>> =
-            Arc::new(Mutex::new(Some(HashMap::new())));
-
-        let (sender1, mut receiver1) = oneshot::channel::<Result<Bytes>>();
-        let (sender2, mut receiver2) = oneshot::channel::<Result<Bytes>>();
-        let (sender3, mut receiver3) = oneshot::channel::<Result<Bytes>>();
-        {
-            let mut map = call_map.lock().unwrap();
-            let m = map.as_mut().unwrap();
-            m.insert(1, sender1);
-            m.insert(2, sender2);
-            m.insert(3, sender3);
-        }
-
-        // Listener processes call_id=1 normally (simulates read_response success)
-        let processed = call_map.lock().unwrap().as_mut().and_then(|m| m.remove(&1));
-        assert!(processed.is_some());
-        let _ = processed.unwrap().send(Ok(Bytes::from("response")));
-
-        // Listener dies, takes remaining
-        if let Some(map) = call_map.lock().unwrap().take() {
-            for (_, call) in map {
-                let _ = call.send(Err(HdfsError::IOError(std::io::Error::new(
-                    ErrorKind::ConnectionAborted,
-                    "RPC listener disconnected",
-                ))));
-            }
-        }
-
-        // Call 1: got a real response
-        let result1 = receiver1.try_recv().unwrap();
-        assert!(result1.is_ok());
-        assert_eq!(result1.unwrap(), Bytes::from("response"));
-
-        // Calls 2 and 3: got ConnectionAborted
-        let result2 = receiver2.try_recv().unwrap();
-        assert!(result2.is_err());
-        match result2.unwrap_err() {
-            HdfsError::IOError(e) => assert_eq!(e.kind(), ErrorKind::ConnectionAborted),
-            other => panic!("Expected IOError, got {:?}", other),
-        }
-
-        let result3 = receiver3.try_recv().unwrap();
-        assert!(result3.is_err());
-        match result3.unwrap_err() {
-            HdfsError::IOError(e) => assert_eq!(e.kind(), ErrorKind::ConnectionAborted),
-            other => panic!("Expected IOError, got {:?}", other),
-        }
-
-        // Map stays poisoned
-        assert!(call_map.lock().unwrap().is_none());
     }
 }

--- a/rust/src/hdfs/connection.rs
+++ b/rust/src/hdfs/connection.rs
@@ -119,7 +119,7 @@ pub(crate) struct RpcConnection {
     user_info: UserInfo,
     next_call_id: AtomicI32,
     alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
-    call_map: Arc<Mutex<HashMap<i32, CallResult>>>,
+    call_map: Arc<Mutex<Option<HashMap<i32, CallResult>>>>,
     sender: mpsc::Sender<Vec<u8>>,
     listener: Option<JoinHandle<()>>,
 }
@@ -134,7 +134,7 @@ impl RpcConnection {
     ) -> Result<Self> {
         let client_id = Uuid::new_v4().to_bytes_le().to_vec();
         let next_call_id = AtomicI32::new(0);
-        let call_map = Arc::new(Mutex::new(HashMap::new()));
+        let call_map = Arc::new(Mutex::new(Some(HashMap::new())));
 
         let mut stream = connect(url, handle).await?;
         stream.write_all("hrpc".as_bytes()).await?;
@@ -300,7 +300,20 @@ impl RpcConnection {
 
         let (sender, receiver) = oneshot::channel::<Result<Bytes>>();
 
-        self.call_map.lock().unwrap().insert(call_id, sender);
+        {
+            let mut map = self.call_map.lock().unwrap();
+            match map.as_mut() {
+                Some(m) => {
+                    m.insert(call_id, sender);
+                }
+                None => {
+                    return Err(HdfsError::IOError(std::io::Error::new(
+                        std::io::ErrorKind::ConnectionAborted,
+                        "RPC listener disconnected",
+                    )));
+                }
+            }
+        }
 
         self.write_messages(&[&conn_header_buf, &header_buf, message])
             .await?;
@@ -310,7 +323,7 @@ impl RpcConnection {
 }
 
 struct RpcListener {
-    call_map: Arc<Mutex<HashMap<i32, CallResult>>>,
+    call_map: Arc<Mutex<Option<HashMap<i32, CallResult>>>>,
     reader: SaslReader,
     alive: bool,
     alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
@@ -318,7 +331,7 @@ struct RpcListener {
 
 impl RpcListener {
     fn new(
-        call_map: Arc<Mutex<HashMap<i32, CallResult>>>,
+        call_map: Arc<Mutex<Option<HashMap<i32, CallResult>>>>,
         reader: SaslReader,
         alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
     ) -> Self {
@@ -344,12 +357,13 @@ impl RpcListener {
         }
         self.alive = false;
 
-        let mut call_map = self.call_map.lock().unwrap();
-        for (_, call) in call_map.drain() {
-            let _ = call.send(Err(HdfsError::IOError(std::io::Error::new(
-                std::io::ErrorKind::ConnectionAborted,
-                "RPC listener disconnected",
-            ))));
+        if let Some(map) = self.call_map.lock().unwrap().take() {
+            for (_, call) in map {
+                let _ = call.send(Err(HdfsError::IOError(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionAborted,
+                    "RPC listener disconnected",
+                ))));
+            }
         }
     }
 
@@ -370,7 +384,12 @@ impl RpcListener {
 
         let call_id = rpc_response.call_id as i32;
 
-        let call = self.call_map.lock().unwrap().remove(&call_id);
+        let call = self
+            .call_map
+            .lock()
+            .unwrap()
+            .as_mut()
+            .and_then(|m| m.remove(&call_id));
 
         if let Some(call) = call {
             match rpc_response.status() {
@@ -760,10 +779,14 @@ impl DatanodeConnectionCache {
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
+    use std::io::ErrorKind;
+    use std::sync::{Arc, Mutex};
 
+    use bytes::Bytes;
     use prost::Message;
+    use tokio::sync::oneshot;
 
-    use crate::{hdfs::connection::MAX_PACKET_HEADER_SIZE, proto::hdfs};
+    use crate::{HdfsError, Result, hdfs::connection::MAX_PACKET_HEADER_SIZE, proto::hdfs};
 
     use super::AlignmentContext;
 
@@ -817,5 +840,63 @@ mod test {
         assert_eq!(router_state.len(), 2);
         assert_eq!(*router_state.get("ns-1").unwrap(), 5);
         assert_eq!(*router_state.get("ns-2").unwrap(), 7);
+    }
+
+    type CallResult = oneshot::Sender<Result<Bytes>>;
+
+    #[test]
+    fn test_call_map_partial_drain_then_poison() {
+        // Simulates: listener processes some responses, then dies mid-stream
+        let call_map: Arc<Mutex<Option<HashMap<i32, CallResult>>>> =
+            Arc::new(Mutex::new(Some(HashMap::new())));
+
+        let (sender1, mut receiver1) = oneshot::channel::<Result<Bytes>>();
+        let (sender2, mut receiver2) = oneshot::channel::<Result<Bytes>>();
+        let (sender3, mut receiver3) = oneshot::channel::<Result<Bytes>>();
+        {
+            let mut map = call_map.lock().unwrap();
+            let m = map.as_mut().unwrap();
+            m.insert(1, sender1);
+            m.insert(2, sender2);
+            m.insert(3, sender3);
+        }
+
+        // Listener processes call_id=1 normally (simulates read_response success)
+        let processed = call_map.lock().unwrap().as_mut().and_then(|m| m.remove(&1));
+        assert!(processed.is_some());
+        let _ = processed.unwrap().send(Ok(Bytes::from("response")));
+
+        // Listener dies, takes remaining
+        if let Some(map) = call_map.lock().unwrap().take() {
+            for (_, call) in map {
+                let _ = call.send(Err(HdfsError::IOError(std::io::Error::new(
+                    ErrorKind::ConnectionAborted,
+                    "RPC listener disconnected",
+                ))));
+            }
+        }
+
+        // Call 1: got a real response
+        let result1 = receiver1.try_recv().unwrap();
+        assert!(result1.is_ok());
+        assert_eq!(result1.unwrap(), Bytes::from("response"));
+
+        // Calls 2 and 3: got ConnectionAborted
+        let result2 = receiver2.try_recv().unwrap();
+        assert!(result2.is_err());
+        match result2.unwrap_err() {
+            HdfsError::IOError(e) => assert_eq!(e.kind(), ErrorKind::ConnectionAborted),
+            other => panic!("Expected IOError, got {:?}", other),
+        }
+
+        let result3 = receiver3.try_recv().unwrap();
+        assert!(result3.is_err());
+        match result3.unwrap_err() {
+            HdfsError::IOError(e) => assert_eq!(e.kind(), ErrorKind::ConnectionAborted),
+            other => panic!("Expected IOError, got {:?}", other),
+        }
+
+        // Map stays poisoned
+        assert!(call_map.lock().unwrap().is_none());
     }
 }


### PR DESCRIPTION
Just for completeness attempt also for

> RpcConnection.call needs some way to know the listener has failed without some form of race condition, likely with something on the call_map directly, though it's likely write_message will fail if the stream has been closed anyway, which would handle ensuring no call gets stuck in limbo after the listener goes down, so might not be the highest priority

 from https://github.com/Kimahriman/hdfs-native/issues/285

Changed call_map from `HashMap` to `Option<HashMap>`. When the listener dies, it calls .take() which drains all pending callers and permanently poisons the map. Any subsequent insert sees None and returns ConnectionAborted immediately, eliminating the race between is_alive() and call_map.insert().

This touches more code than the previous PRs, so perhaps best to be more careful with this one.