### PR TITLE
feat: add user parameter to ClientBuilder

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -418,10 +418,7 @@ impl Client {
 
         let rt_holder = RuntimeHolder::new(rt);
 
-        let user_info = match user {
-            Some(effective_user) => User::get_user_info_with_effective_user(effective_user),
-            None => User::get_user_info(),
-        };
+        let user_info = User::get_user_info(user.clone(), config.security_enabled());
         let username = user_info
             .effective_user
             .as_deref()
@@ -440,6 +437,7 @@ impl Client {
                     &resolved_url,
                     Arc::clone(&config),
                     rt_holder.get_handle(),
+                    user.clone(),
                 )?;
                 let protocol = Arc::new(NamenodeProtocol::new(proxy, rt_holder.get_handle()));
 
@@ -454,6 +452,7 @@ impl Client {
                 resolved_url.host_str().expect("URL must have a host"),
                 Arc::clone(&config),
                 rt_holder.get_handle(),
+                user.clone(),
                 home_dir,
             )?,
             _ => {
@@ -474,6 +473,7 @@ impl Client {
         host: &str,
         config: Arc<Configuration>,
         handle: Handle,
+        effective_user: Option<String>,
         home_dir: String,
     ) -> Result<MountTable> {
         let mut mounts: Vec<MountLink> = Vec::new();
@@ -491,7 +491,12 @@ impl Client {
                     "Only hdfs mounts are supported for viewfs".to_string(),
                 ));
             }
-            let proxy = NameServiceProxy::new(&url, Arc::clone(&config), handle.clone())?;
+            let proxy = NameServiceProxy::new(
+                &url,
+                Arc::clone(&config),
+                handle.clone(),
+                effective_user.clone(),
+            )?;
             let protocol = Arc::new(NamenodeProtocol::new(proxy, handle.clone()));
 
             if let Some(prefix) = viewfs_path {
@@ -1196,6 +1201,7 @@ mod test {
             &Url::parse(url).unwrap(),
             Arc::new(Configuration::new(None, None).unwrap()),
             RT.handle().clone(),
+            None,
         )
         .unwrap();
         Arc::new(NamenodeProtocol::new(proxy, RT.handle().clone()))
@@ -1365,6 +1371,18 @@ mod test {
                 .build()
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn test_with_user_sets_relative_path_home_dir() {
+        let client = ClientBuilder::new()
+            .with_url("hdfs://127.0.0.1:9000")
+            .with_user("alice")
+            .build()
+            .unwrap();
+
+        let (_, resolved) = client.mount_table.resolve("file");
+        assert_eq!(resolved, "/user/alice/file");
     }
 
     #[test]

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -259,6 +259,7 @@ pub struct ClientBuilder {
     config: Option<HashMap<String, String>>,
     config_dir: Option<String>,
     runtime: Option<IORuntime>,
+    user: Option<String>,
 }
 
 impl ClientBuilder {
@@ -300,6 +301,12 @@ impl ClientBuilder {
         self
     }
 
+    /// Set the effective user for the client. If not set, the client will detect user from environment variables `HADOOP_USER_NAME` or `HADOOP_PROXY_USER`.
+    pub fn with_user(mut self, user: impl Into<String>) -> Self {
+        self.user = Some(user.into());
+        self
+    }
+
     /// Create the [Client] instance from the provided settings
     pub fn build(self) -> Result<Client> {
         let config = Configuration::new(self.config_dir, self.config)?;
@@ -309,7 +316,7 @@ impl ClientBuilder {
             Client::default_fs(&config)?
         };
 
-        Client::build(&url, config, self.runtime)
+        Client::build(&url, config, self.runtime, self.user)
     }
 }
 
@@ -359,19 +366,24 @@ impl Client {
     #[deprecated(since = "0.12.0", note = "Use ClientBuilder instead")]
     pub fn new(url: &str) -> Result<Self> {
         let parsed_url = Url::parse(url)?;
-        Self::build(&parsed_url, Configuration::new(None, None)?, None)
+        Self::build(&parsed_url, Configuration::new(None, None)?, None, None)
     }
 
     #[deprecated(since = "0.12.0", note = "Use ClientBuilder instead")]
     pub fn new_with_config(url: &str, config: HashMap<String, String>) -> Result<Self> {
         let parsed_url = Url::parse(url)?;
-        Self::build(&parsed_url, Configuration::new(None, Some(config))?, None)
+        Self::build(
+            &parsed_url,
+            Configuration::new(None, Some(config))?,
+            None,
+            None,
+        )
     }
 
     #[deprecated(since = "0.12.0", note = "Use ClientBuilder instead")]
     pub fn default_with_config(config: HashMap<String, String>) -> Result<Self> {
         let config = Configuration::new(None, Some(config))?;
-        Self::build(&Self::default_fs(&config)?, config, None)
+        Self::build(&Self::default_fs(&config)?, config, None, None)
     }
 
     fn default_fs(config: &Configuration) -> Result<Url> {
@@ -384,7 +396,12 @@ impl Client {
         Ok(Url::parse(url)?)
     }
 
-    fn build(url: &Url, config: Configuration, rt: Option<IORuntime>) -> Result<Self> {
+    fn build(
+        url: &Url,
+        config: Configuration,
+        rt: Option<IORuntime>,
+        user: Option<String>,
+    ) -> Result<Self> {
         let resolved_url = if !url.has_host() {
             let default_url = Self::default_fs(&config)?;
             if url.scheme() != default_url.scheme() || !default_url.has_host() {
@@ -401,7 +418,10 @@ impl Client {
 
         let rt_holder = RuntimeHolder::new(rt);
 
-        let user_info = User::get_user_info();
+        let user_info = match user {
+            Some(effective_user) => User::get_user_info_with_effective_user(effective_user),
+            None => User::get_user_info(),
+        };
         let username = user_info
             .effective_user
             .as_deref()

--- a/rust/src/hdfs/connection.rs
+++ b/rust/src/hdfs/connection.rs
@@ -129,6 +129,7 @@ impl RpcConnection {
         url: &str,
         alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
         nameservice: Option<&str>,
+        effective_user: Option<String>,
         config: &Configuration,
         handle: &Handle,
     ) -> Result<Self> {
@@ -152,7 +153,8 @@ impl RpcConnection {
         let service = nameservice
             .map(|ns| format!("ha-hdfs:{ns}"))
             .unwrap_or(url.to_string());
-        let (user_info, reader, writer) = negotiate_sasl_session(stream, &service, config).await?;
+        let (user_info, reader, writer) =
+            negotiate_sasl_session(stream, &service, config, effective_user).await?;
         let (sender, receiver) = mpsc::channel::<Vec<u8>>(1000);
 
         let mut conn = RpcConnection {
@@ -779,12 +781,15 @@ impl DatanodeConnectionCache {
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
+    use std::sync::atomic::AtomicI32;
+    use std::sync::{Arc, Mutex};
 
     use prost::Message;
+    use tokio::sync::mpsc;
 
-    use crate::{hdfs::connection::MAX_PACKET_HEADER_SIZE, proto::hdfs};
+    use crate::{hdfs::connection::MAX_PACKET_HEADER_SIZE, proto::hdfs, security::user::UserInfo};
 
-    use super::AlignmentContext;
+    use super::{AlignmentContext, RpcConnection};
 
     #[test]
     fn test_max_packet_header_size() {
@@ -836,5 +841,27 @@ mod test {
         assert_eq!(router_state.len(), 2);
         assert_eq!(*router_state.get("ns-1").unwrap(), 5);
         assert_eq!(*router_state.get("ns-2").unwrap(), 7);
+    }
+
+    #[test]
+    fn test_connection_context_uses_provided_user_info() {
+        let (sender, _receiver) = mpsc::channel(1);
+        let conn = RpcConnection {
+            client_id: Vec::new(),
+            user_info: UserInfo {
+                real_user: Some("real-user".to_string()),
+                effective_user: Some("alice".to_string()),
+            },
+            next_call_id: AtomicI32::new(0),
+            alignment_context: None,
+            call_map: Arc::new(Mutex::new(Some(HashMap::new()))),
+            sender,
+            listener: None,
+        };
+
+        let context = conn.get_connection_context();
+        let user_info = context.user_info.unwrap();
+        assert_eq!(user_info.real_user.as_deref(), Some("real-user"));
+        assert_eq!(user_info.effective_user.as_deref(), Some("alice"));
     }
 }

--- a/rust/src/hdfs/proxy.rs
+++ b/rust/src/hdfs/proxy.rs
@@ -28,6 +28,7 @@ struct ProxyConnection {
     inner: Arc<tokio::sync::Mutex<Option<RpcConnection>>>,
     alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
     nameservice: Option<String>,
+    effective_user: Option<String>,
     config: Arc<Configuration>,
     handle: Handle,
 }
@@ -37,6 +38,7 @@ impl ProxyConnection {
         url: String,
         alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
         nameservice: Option<String>,
+        effective_user: Option<String>,
         config: Arc<Configuration>,
         handle: Handle,
     ) -> Self {
@@ -45,6 +47,7 @@ impl ProxyConnection {
             inner: Arc::new(tokio::sync::Mutex::new(None)),
             alignment_context,
             nameservice,
+            effective_user,
             config,
             handle,
         }
@@ -62,6 +65,7 @@ impl ProxyConnection {
                                 &self.url,
                                 self.alignment_context.clone(),
                                 self.nameservice.as_deref(),
+                                self.effective_user.clone(),
                                 &self.config,
                                 &self.handle,
                             )
@@ -113,6 +117,7 @@ impl NameServiceProxy {
         nameservice: &Url,
         config: Arc<Configuration>,
         handle: Handle,
+        effective_user: Option<String>,
     ) -> Result<Self> {
         let host = nameservice.host_str().ok_or(HdfsError::InvalidArgument(
             "No host for name service".to_string(),
@@ -147,6 +152,7 @@ impl NameServiceProxy {
                 url,
                 alignment_context,
                 None,
+                effective_user,
                 Arc::clone(&config),
                 handle,
             )]
@@ -160,6 +166,7 @@ impl NameServiceProxy {
                         url,
                         alignment_context.clone(),
                         Some(host.to_string()),
+                        effective_user.clone(),
                         Arc::clone(&config),
                         handle.clone(),
                     )

--- a/rust/src/security/gssapi.rs
+++ b/rust/src/security/gssapi.rs
@@ -470,6 +470,7 @@ fn check_gss_ok(mut major: u32, mut minor: u32) -> crate::Result<()> {
 #[derive(Debug)]
 pub struct GssapiSession {
     state: GssapiState,
+    effective_user: Option<String>,
 }
 
 enum GssapiState {
@@ -491,12 +492,19 @@ impl fmt::Debug for GssapiState {
 }
 
 impl GssapiSession {
-    pub(crate) fn new(service: &str, hostname: &str) -> crate::Result<Self> {
+    pub(crate) fn new(
+        service: &str,
+        hostname: &str,
+        effective_user: Option<String>,
+    ) -> crate::Result<Self> {
         let targ_name = format!("{service}@{hostname}");
 
         let target = GssName::with_target(&targ_name)?;
         let state = GssapiState::Pending(GssClientCtx::new(target));
-        Ok(Self { state })
+        Ok(Self {
+            state,
+            effective_user,
+        })
     }
 
     pub(crate) fn get_default_principal() -> crate::Result<String> {
@@ -597,7 +605,9 @@ impl SaslSession for GssapiSession {
     fn get_user_info(&self) -> crate::Result<super::user::UserInfo> {
         match &self.state {
             GssapiState::Completed((principal, _)) => {
-                Ok(User::get_user_info_from_principal(principal))
+                let user_info =
+                    User::get_user_info_from_principal(principal, self.effective_user.clone());
+                Ok(user_info)
             }
             _ => Err(HdfsError::SASLError(
                 "SASL session doesn't have security layer".to_string(),

--- a/rust/src/security/sasl.rs
+++ b/rust/src/security/sasl.rs
@@ -39,6 +39,7 @@ const SASL_CALL_ID: i32 = -33;
 const SASL_TRANSFER_MAGIC_NUMBER: i32 = 0xDEADBEEFu32 as i32;
 const HDFS_DELEGATION_TOKEN: &str = "HDFS_DELEGATION_TOKEN";
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum AuthMethod {
     Simple,
     Kerberos,
@@ -71,13 +72,14 @@ pub(crate) async fn negotiate_sasl_session(
     stream: TcpStream,
     service: &str,
     config: &Configuration,
+    effective_user: Option<String>,
 ) -> Result<(UserInfo, SaslReader, SaslWriter)> {
     let (reader, writer) = stream.into_split();
     let mut reader = SaslReader::new(reader);
     let mut writer = SaslWriter::new(writer);
 
     if !config.security_enabled() {
-        return Ok((User::get_simple_user(), reader, writer));
+        return Ok((User::get_simple_user(effective_user), reader, writer));
     }
 
     let rpc_sasl = RpcSaslProto {
@@ -95,7 +97,8 @@ pub(crate) async fn negotiate_sasl_session(
         debug!("Handling SASL message: {:?}", message);
         match SaslState::try_from(message.state).unwrap() {
             SaslState::Negotiate => {
-                let (mut selected_auth, selected_session) = select_method(&message.auths, service)?;
+                let (mut selected_auth, selected_session) =
+                    select_method(&message.auths, service, effective_user.clone())?;
                 session = selected_session;
 
                 let token = if let Some(session) = session.as_mut() {
@@ -156,10 +159,10 @@ pub(crate) async fn negotiate_sasl_session(
         }
     }
 
-    let user_info = if let Some(s) = session.as_ref() {
-        s.get_user_info()?
+    let user_info = if let Some(session) = session.as_ref() {
+        session.get_user_info()?
     } else {
-        User::get_simple_user()
+        User::get_simple_user(effective_user)
     };
     let session = session
         .filter(|x| {
@@ -178,6 +181,7 @@ pub(crate) async fn negotiate_sasl_session(
 fn select_method(
     auths: &[SaslAuth],
     service: &str,
+    effective_user: Option<String>,
 ) -> Result<(SaslAuth, Option<Box<dyn SaslSession>>)> {
     let user = User::get();
     for auth in auths.iter() {
@@ -189,7 +193,8 @@ fn select_method(
                 return Ok((auth.clone(), None));
             }
             (Some(AuthMethod::Kerberos), _) => {
-                let session = GssapiSession::new(auth.protocol(), auth.server_id())?;
+                let session =
+                    GssapiSession::new(auth.protocol(), auth.server_id(), effective_user)?;
                 return Ok((auth.clone(), Some(Box::new(session))));
             }
             (Some(AuthMethod::Token), Some(token)) => {

--- a/rust/src/security/user.rs
+++ b/rust/src/security/user.rs
@@ -365,44 +365,37 @@ impl User {
             })
     }
 
-    pub(crate) fn get_user_info_from_principal(principal: &str) -> UserInfo {
-        let username = User::get_user_from_principal(principal);
-        let proxy_user = env::var(HADOOP_PROXY_USER).ok();
+    pub(crate) fn get_user_info_from_principal(
+        principal: &str,
+        effective_user: Option<String>,
+    ) -> UserInfo {
         UserInfo {
-            real_user: Some(username),
-            effective_user: proxy_user,
+            real_user: Some(User::get_user_from_principal(principal)),
+            effective_user: effective_user.or_else(|| env::var(HADOOP_PROXY_USER).ok()),
         }
     }
 
-    pub(crate) fn get_simple_user() -> UserInfo {
-        let effective_user = env::var(HADOOP_USER_NAME).ok().unwrap_or_else(username);
+    pub(crate) fn get_simple_user(effective_user: Option<String>) -> UserInfo {
         UserInfo {
             real_user: None,
-            effective_user: Some(effective_user),
+            effective_user: Some(
+                effective_user
+                    .or_else(|| env::var(HADOOP_USER_NAME).ok())
+                    .unwrap_or_else(username),
+            ),
         }
     }
 
-    /// set effective user according to environment variable
-    pub(crate) fn get_user_info() -> UserInfo {
-        if let Ok(principal) = GssapiSession::get_default_principal() {
-            return User::get_user_info_from_principal(&principal);
+    pub(crate) fn get_user_info(
+        effective_user: Option<String>,
+        security_enabled: bool,
+    ) -> UserInfo {
+        if security_enabled && let Ok(principal) = GssapiSession::get_default_principal() {
+            let user_info = User::get_user_info_from_principal(&principal, effective_user);
+            return user_info;
         }
 
-        User::get_simple_user()
-    }
-
-    /// user given effective user instead of getting it from environment variable
-    pub(crate) fn get_user_info_with_effective_user(effective_user: String) -> UserInfo {
-        let real_user = if let Ok(principal) = GssapiSession::get_default_principal() {
-            Some(User::get_user_from_principal(&principal))
-        } else {
-            None
-        };
-
-        UserInfo {
-            real_user,
-            effective_user: Some(effective_user),
-        }
+        User::get_simple_user(effective_user)
     }
 
     pub(crate) fn get_user_from_principal(principal: &str) -> String {
@@ -424,6 +417,14 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use super::*;
+
+    #[test]
+    fn test_get_user_info_uses_provided_effective_user_for_simple_auth() {
+        let user_info = User::get_user_info(Some("alice".to_string()), false);
+
+        assert_eq!(user_info.real_user, None);
+        assert_eq!(user_info.effective_user.as_deref(), Some("alice"));
+    }
 
     #[test]
     fn test_load_writable_token() {

--- a/rust/src/security/user.rs
+++ b/rust/src/security/user.rs
@@ -382,12 +382,27 @@ impl User {
         }
     }
 
+    /// set effective user according to environment variable
     pub(crate) fn get_user_info() -> UserInfo {
         if let Ok(principal) = GssapiSession::get_default_principal() {
             return User::get_user_info_from_principal(&principal);
         }
 
         User::get_simple_user()
+    }
+
+    /// user given effective user instead of getting it from environment variable
+    pub(crate) fn get_user_info_with_effective_user(effective_user: String) -> UserInfo {
+        let real_user = if let Ok(principal) = GssapiSession::get_default_principal() {
+            Some(User::get_user_from_principal(&principal))
+        } else {
+            None
+        };
+
+        UserInfo {
+            real_user,
+            effective_user: Some(effective_user),
+        }
     }
 
     pub(crate) fn get_user_from_principal(principal: &str) -> String {


### PR DESCRIPTION
Add user parameter to ClientBuilder to allow programmatically setting effective user. When `with_user` not set, use env HADOOP_USER_NAME or HADOOP_PROXY_USER. If `with_user` is set, use the given user as effective user. 

This closes #289 .