### PR TITLE
Implement Read/Seek/Write/AsyncRead/AsyncSeek traits

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -263,7 +263,7 @@ impl RawFileReader {
     }
 
     pub fn seek(&mut self, pos: usize) {
-        self.inner.seek(pos);
+        self.inner.set_position(pos);
     }
 
     pub fn tell(&self) -> usize {
@@ -276,7 +276,9 @@ impl RawFileReader {
         } else {
             len as usize
         };
-        Ok(Cow::from(py.detach(|| self.inner.read(read_len))?.to_vec()))
+        Ok(Cow::from(
+            py.detach(|| self.inner.read_bytes(read_len))?.to_vec(),
+        ))
     }
 
     pub fn read_range(&self, offset: usize, len: usize, py: Python) -> PyHdfsResult<Cow<'_, [u8]>> {
@@ -382,7 +384,7 @@ struct RawFileWriter {
 #[pymethods]
 impl RawFileWriter {
     pub fn write(&mut self, buf: Vec<u8>, py: Python) -> PyHdfsResult<usize> {
-        Ok(py.detach(|| self.inner.write(Bytes::from(buf)))?)
+        Ok(py.detach(|| self.inner.write_bytes(Bytes::from(buf)))?)
     }
 
     pub fn close(&mut self, py: Python) -> PyHdfsResult<()> {
@@ -624,7 +626,7 @@ impl AsyncRawFileReader {
     }
 
     pub fn seek(&mut self, pos: usize) {
-        self.inner.seek(pos);
+        self.inner.set_position(pos);
     }
 
     pub fn tell(&self) -> usize {
@@ -637,7 +639,7 @@ impl AsyncRawFileReader {
         } else {
             len as usize
         };
-        Ok(Cow::from(self.inner.read(read_len).await?.to_vec()))
+        Ok(Cow::from(self.inner.read_bytes(read_len).await?.to_vec()))
     }
 
     pub async fn read_range(&self, offset: usize, len: usize) -> PyHdfsResult<Cow<'static, [u8]>> {
@@ -661,7 +663,7 @@ struct AsyncRawFileWriter {
 #[pymethods]
 impl AsyncRawFileWriter {
     pub async fn write(&mut self, buf: Vec<u8>) -> PyHdfsResult<usize> {
-        Ok(self.inner.write(Bytes::from(buf)).await?)
+        Ok(self.inner.write_bytes(Bytes::from(buf)).await?)
     }
 
     pub async fn close(&mut self) -> PyHdfsResult<()> {

--- a/rust/benches/io.rs
+++ b/rust/benches/io.rs
@@ -18,7 +18,7 @@ async fn write_file(client: &Client, path: &str, ints: usize) {
     for i in 0..ints {
         data.put_u32(i as u32);
     }
-    writer.write(data.freeze()).await.unwrap();
+    writer.write_bytes(data.freeze()).await.unwrap();
     writer.close().await.unwrap();
 }
 
@@ -117,7 +117,7 @@ fn bench(c: &mut Criterion) {
                 .await
                 .unwrap();
 
-            writer.write(buf.clone()).await.unwrap();
+            writer.write_bytes(buf.clone()).await.unwrap();
             writer.close().await.unwrap();
         })
     });
@@ -152,7 +152,7 @@ fn bench(c: &mut Criterion) {
                 .await
                 .unwrap();
 
-            writer.write(buf.clone()).await.unwrap();
+            writer.write_bytes(buf.clone()).await.unwrap();
             writer.close().await.unwrap();
         })
     });

--- a/rust/examples/simple.rs
+++ b/rust/examples/simple.rs
@@ -48,13 +48,13 @@ async fn main() {
         .await
         .unwrap();
 
-    writer.write(vec![1, 2, 3, 4].into()).await.unwrap();
+    writer.write_bytes(vec![1, 2, 3, 4].into()).await.unwrap();
     writer.close().await.unwrap();
 
     // Append to an existing file
     let mut writer = client.append("/hdfs-native-write").await.unwrap();
 
-    writer.write(vec![5, 6, 7, 8].into()).await.unwrap();
+    writer.write_bytes(vec![5, 6, 7, 8].into()).await.unwrap();
     writer.close().await.unwrap();
 
     // Read a file

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -75,7 +75,7 @@ impl FileReader {
     }
 
     /// Sets the cursor to the position. Panics if the position is beyond the end of the file
-    pub fn seek(&mut self, pos: usize) {
+    pub fn set_position(&mut self, pos: usize) {
         if pos > self.file_length() {
             panic!("Cannot seek beyond the end of a file");
         }
@@ -90,7 +90,7 @@ impl FileReader {
 
     /// Read up to `len` bytes into a new [Bytes] object, advancing the internal position in the file.
     /// An empty [Bytes] object will be returned if the end of the file has been reached.
-    pub async fn read(&mut self, len: usize) -> Result<Bytes> {
+    pub async fn read_bytes(&mut self, len: usize) -> Result<Bytes> {
         self.pending_read = None;
         if self.position >= self.file_length() {
             Ok(Bytes::new())
@@ -103,7 +103,7 @@ impl FileReader {
 
     /// Read up to `buf.len()` bytes into the provided slice, advancing the internal position in the file.
     /// Returns the number of bytes that were read, or 0 if the end of the file has been reached.
-    pub async fn read_buf(&mut self, buf: &mut [u8]) -> Result<usize> {
+    pub async fn read_into(&mut self, buf: &mut [u8]) -> Result<usize> {
         self.pending_read = None;
         if self.position >= self.file_length() {
             Ok(0)
@@ -346,7 +346,7 @@ impl FileWriter {
         Ok(self.block_writer.as_mut().unwrap())
     }
 
-    pub async fn write(&mut self, mut buf: Bytes) -> Result<usize> {
+    pub async fn write_bytes(&mut self, mut buf: Bytes) -> Result<usize> {
         let bytes_to_write = buf.len();
         while !buf.is_empty() {
             let block_writer = self.get_block_writer().await?;

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -1,10 +1,14 @@
+use std::io;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt, stream};
 use log::warn;
+use tokio::io::{AsyncRead, ReadBuf};
 use tokio::runtime::Handle;
 
 use crate::common::config::Configuration;
@@ -18,6 +22,15 @@ use crate::{HdfsError, Result};
 const COMPLETE_RETRY_DELAY_MS: u64 = 500;
 const COMPLETE_RETRIES: u32 = 5;
 
+fn io_error(error: HdfsError) -> io::Error {
+    io::Error::other(error)
+}
+
+struct PendingRead {
+    stream: BoxStream<'static, Result<Bytes>>,
+    end_position: usize,
+}
+
 pub struct FileReader {
     protocol: Arc<NamenodeProtocol>,
     located_blocks: hdfs::LocatedBlocksProto,
@@ -25,6 +38,7 @@ pub struct FileReader {
     position: usize,
     config: Arc<Configuration>,
     handle: Handle,
+    pending_read: Option<std::sync::Mutex<PendingRead>>,
 }
 
 impl FileReader {
@@ -42,6 +56,7 @@ impl FileReader {
             position: 0,
             config,
             handle,
+            pending_read: None,
         }
     }
 
@@ -64,6 +79,7 @@ impl FileReader {
         if pos > self.file_length() {
             panic!("Cannot seek beyond the end of a file");
         }
+        self.pending_read = None;
         self.position = pos;
     }
 
@@ -75,6 +91,7 @@ impl FileReader {
     /// Read up to `len` bytes into a new [Bytes] object, advancing the internal position in the file.
     /// An empty [Bytes] object will be returned if the end of the file has been reached.
     pub async fn read(&mut self, len: usize) -> Result<Bytes> {
+        self.pending_read = None;
         if self.position >= self.file_length() {
             Ok(Bytes::new())
         } else {
@@ -87,6 +104,7 @@ impl FileReader {
     /// Read up to `buf.len()` bytes into the provided slice, advancing the internal position in the file.
     /// Returns the number of bytes that were read, or 0 if the end of the file has been reached.
     pub async fn read_buf(&mut self, buf: &mut [u8]) -> Result<usize> {
+        self.pending_read = None;
         if self.position >= self.file_length() {
             Ok(0)
         } else {
@@ -164,6 +182,72 @@ impl FileReader {
             .collect();
 
         stream::iter(block_streams).flatten()
+    }
+}
+
+impl AsyncRead for FileReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let starting_len = buf.filled().len();
+
+        loop {
+            if self.pending_read.is_none() {
+                if self.position >= self.file_length() {
+                    return Poll::Ready(Ok(()));
+                }
+
+                let offset = self.position;
+                let len = usize::min(buf.remaining(), self.file_length() - self.position);
+                let stream = self.read_range_stream(offset, len).boxed();
+                self.pending_read = Some(std::sync::Mutex::new(PendingRead {
+                    stream,
+                    end_position: offset + len,
+                }));
+            }
+
+            let poll_result = {
+                let mut pending = self.pending_read.as_ref().unwrap().lock().unwrap();
+                Pin::new(&mut pending.stream).poll_next(cx)
+            };
+
+            match poll_result {
+                Poll::Ready(Some(Ok(bytes))) => {
+                    self.position += bytes.len();
+                    buf.put_slice(&bytes);
+
+                    if self.pending_read.as_ref().is_some_and(|pending| {
+                        self.position >= pending.lock().unwrap().end_position
+                    }) {
+                        self.pending_read = None;
+                    }
+
+                    if buf.remaining() == 0 {
+                        return Poll::Ready(Ok(()));
+                    }
+                }
+                Poll::Ready(Some(Err(error))) => {
+                    self.pending_read = None;
+                    return Poll::Ready(Err(io_error(error)));
+                }
+                Poll::Ready(None) => {
+                    self.pending_read = None;
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Pending => {
+                    if buf.filled().len() > starting_len {
+                        return Poll::Ready(Ok(()));
+                    }
+                    return Poll::Pending;
+                }
+            }
+        }
     }
 }
 

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, SeekFrom};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -8,7 +8,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt, stream};
 use log::warn;
-use tokio::io::{AsyncRead, ReadBuf};
+use tokio::io::{AsyncRead, AsyncSeek, ReadBuf};
 use tokio::runtime::Handle;
 
 use crate::common::config::Configuration;
@@ -248,6 +248,32 @@ impl AsyncRead for FileReader {
                 }
             }
         }
+    }
+}
+
+impl AsyncSeek for FileReader {
+    fn start_seek(mut self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
+        let file_length = self.file_length() as i128;
+        let current = self.tell() as i128;
+        let new_pos = match position {
+            SeekFrom::Start(pos) => i128::from(pos),
+            SeekFrom::End(offset) => file_length + i128::from(offset),
+            SeekFrom::Current(offset) => current + i128::from(offset),
+        };
+
+        if new_pos < 0 || new_pos > file_length {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "cannot seek outside of file bounds",
+            ));
+        }
+
+        self.set_position(new_pos as usize);
+        Ok(())
+    }
+
+    fn poll_complete(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+        Poll::Ready(Ok(self.tell() as u64))
     }
 }
 

--- a/rust/src/sync.rs
+++ b/rust/src/sync.rs
@@ -5,6 +5,7 @@
 //! without managing an async runtime directly.
 
 use std::future::Future;
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
@@ -16,6 +17,10 @@ use crate::acl::{AclEntry, AclStatus};
 use crate::client::{self, ContentSummary, FileStatus, WriteOptions};
 use crate::file::{FileReader as AsyncFileReader, FileWriter as AsyncFileWriter};
 use crate::{Result, client::IORuntime};
+
+fn io_error(error: crate::HdfsError) -> io::Error {
+    io::Error::other(error)
+}
 
 /// Builds a new synchronous [`Client`] instance.
 #[derive(Default)]
@@ -236,8 +241,8 @@ impl FileReader {
     }
 
     /// Sets the cursor position.
-    pub fn seek(&mut self, pos: usize) {
-        self.inner.seek(pos);
+    pub fn set_position(&mut self, pos: usize) {
+        self.inner.set_position(pos);
     }
 
     /// Returns the current cursor position in the file.
@@ -246,13 +251,13 @@ impl FileReader {
     }
 
     /// Read up to `len` bytes, advancing the internal position.
-    pub fn read(&mut self, len: usize) -> Result<Bytes> {
-        self.rt.block_on(self.inner.read(len))
+    pub fn read_bytes(&mut self, len: usize) -> Result<Bytes> {
+        self.rt.block_on(self.inner.read_bytes(len))
     }
 
     /// Read up to `buf.len()` bytes into the provided slice.
-    pub fn read_buf(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.rt.block_on(self.inner.read_buf(buf))
+    pub fn read_into(&mut self, buf: &mut [u8]) -> Result<usize> {
+        self.rt.block_on(self.inner.read_into(buf))
     }
 
     /// Read up to `len` bytes starting at `offset`.
@@ -271,6 +276,34 @@ impl FileReader {
             inner: Mutex::new(self.inner.read_range_stream(offset, len).boxed()),
             rt: Arc::clone(&self.rt),
         }
+    }
+}
+
+impl Read for FileReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.read_into(buf).map_err(io_error)
+    }
+}
+
+impl Seek for FileReader {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let file_length = self.file_length() as i128;
+        let current = self.tell() as i128;
+        let new_pos = match pos {
+            SeekFrom::Start(pos) => i128::from(pos),
+            SeekFrom::End(offset) => file_length + i128::from(offset),
+            SeekFrom::Current(offset) => current + i128::from(offset),
+        };
+
+        if new_pos < 0 || new_pos > file_length {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "cannot seek outside of file bounds",
+            ));
+        }
+
+        self.inner.set_position(new_pos as usize);
+        Ok(new_pos as u64)
     }
 }
 
@@ -296,12 +329,23 @@ pub struct FileWriter {
 
 impl FileWriter {
     /// Write bytes to the file.
-    pub fn write(&mut self, buf: Bytes) -> Result<usize> {
-        self.rt.block_on(self.inner.write(buf))
+    pub fn write_bytes(&mut self, buf: Bytes) -> Result<usize> {
+        self.rt.block_on(self.inner.write_bytes(buf))
     }
 
     /// Close the file writer.
     pub fn close(&mut self) -> Result<()> {
         self.rt.block_on(self.inner.close())
+    }
+}
+
+impl Write for FileWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.write_bytes(Bytes::copy_from_slice(buf))
+            .map_err(io_error)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }

--- a/rust/src/sync.rs
+++ b/rust/src/sync.rs
@@ -55,6 +55,13 @@ impl ClientBuilder {
         self
     }
 
+    /// Set the effective user for the client. If not set, the client will detect user from
+    /// environment variables `HADOOP_USER_NAME` or `HADOOP_PROXY_USER`.
+    pub fn with_user(mut self, user: impl Into<String>) -> Self {
+        self.inner = self.inner.with_user(user);
+        self
+    }
+
     /// Create the synchronous [`Client`] from the provided settings.
     pub fn build(self) -> Result<Client> {
         let rt = Arc::new(Runtime::new()?);

--- a/rust/tests/test_ec.rs
+++ b/rust/tests/test_ec.rs
@@ -179,7 +179,7 @@ mod test {
                     buf.put_u32(i);
                 }
 
-                writer.write(buf.freeze()).await?;
+                writer.write_bytes(buf.freeze()).await?;
                 writer.close().await?;
 
                 let reader = client.read(&file).await?;
@@ -210,7 +210,7 @@ mod test {
                 buf.put_u32(i);
             }
 
-            writer.write(buf.freeze()).await?;
+            writer.write_bytes(buf.freeze()).await?;
             writer.close().await?;
 
             let mut writer = client.append(&file).await?;
@@ -221,7 +221,7 @@ mod test {
                 buf.put_u32(i as u32);
             }
 
-            writer.write(buf.freeze()).await?;
+            writer.write_bytes(buf.freeze()).await?;
             writer.close().await?;
 
             let _ = EC_FAULT_INJECTOR.lock().unwrap().take();

--- a/rust/tests/test_integration.rs
+++ b/rust/tests/test_integration.rs
@@ -16,7 +16,7 @@ mod test {
     use serial_test::serial;
     use std::collections::HashSet;
     use std::io::{Read, Seek, SeekFrom, Write};
-    use tokio::io::AsyncReadExt;
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
     use whoami::username;
 
     #[tokio::test]
@@ -394,6 +394,12 @@ mod test {
             &BytesMut::from(&async_read_data[..]),
             Some("async read".to_string()),
         );
+
+        let mut reader = client.read("/newfile").await?;
+        assert_eq!(reader.seek(SeekFrom::Start(4)).await?, 4);
+        let mut async_seek_data = [0; 4];
+        reader.read_exact(&mut async_seek_data).await?;
+        assert_eq!(async_seek_data, 1i32.to_be_bytes());
 
         assert!(client.delete("/newfile", false).await.is_ok_and(|r| r));
 

--- a/rust/tests/test_integration.rs
+++ b/rust/tests/test_integration.rs
@@ -4,7 +4,7 @@ mod common;
 #[cfg(feature = "integration-test")]
 mod test {
     use crate::common::{TEST_FILE_INTS, assert_bufs_equal};
-    use bytes::{BufMut, Bytes, BytesMut};
+    use bytes::{BufMut, BytesMut};
     use hdfs_native::{
         Client, Result, WriteOptions,
         acl::AclEntry,
@@ -192,7 +192,7 @@ mod test {
 
         let write_options = WriteOptions::default().overwrite(true);
         let mut writer = client.create("/syncfile", &write_options)?;
-        writer.write(Bytes::from_static(b"hello "))?;
+        writer.write_all(b"hello ").unwrap();
         writer.close()?;
 
         assert_eq!(client.get_file_info("/syncfile")?.length, 6);
@@ -207,15 +207,16 @@ mod test {
         assert_eq!(statuses[0].path, "/syncfile");
 
         let mut writer = client.append("/syncfile")?;
-        writer.write(Bytes::from_static(b"sync"))?;
+        writer.write_all(b"sync").unwrap();
         writer.close()?;
 
         let mut reader = client.read("/syncfile")?;
         assert_eq!(reader.file_length(), 10);
-        let prefix = reader.read(6)?;
-        assert_eq!(prefix.as_ref(), b"hello ");
+        let mut prefix = [0; 6];
+        reader.read_exact(&mut prefix).unwrap();
+        assert_eq!(&prefix, b"hello ");
         assert_eq!(reader.tell(), 6);
-        reader.seek(0);
+        assert_eq!(Seek::seek(&mut reader, SeekFrom::Start(0)).unwrap(), 0);
 
         let data = reader.read_range(0, reader.file_length())?;
         assert_eq!(data.as_ref(), b"hello sync");
@@ -243,7 +244,7 @@ mod test {
 
         let mut file = client.create("/testfile", WriteOptions::default()).await?;
         for i in 0..TEST_FILE_INTS as i32 {
-            file.write(i.to_be_bytes().to_vec().into()).await?;
+            file.write_bytes(i.to_be_bytes().to_vec().into()).await?;
         }
         file.close().await?;
 
@@ -357,13 +358,13 @@ mod test {
 
         let buf = data.freeze();
 
-        writer.write(buf).await?;
+        writer.write_bytes(buf).await?;
         writer.close().await?;
 
         assert_eq!(client.get_file_info("/newfile").await?.length, 4096);
 
         let mut reader = client.read("/newfile").await?;
-        let read_data = reader.read(reader.file_length()).await?;
+        let read_data = reader.read_bytes(reader.file_length()).await?;
 
         assert_bufs_equal(&file_contents, &read_data, None);
 
@@ -376,11 +377,11 @@ mod test {
         let buf = data.freeze();
 
         let mut writer = client.append("/newfile").await?;
-        writer.write(buf).await?;
+        writer.write_bytes(buf).await?;
         writer.close().await?;
 
         let mut reader = client.read("/newfile").await?;
-        let read_data = reader.read(reader.file_length()).await?;
+        let read_data = reader.read_bytes(reader.file_length()).await?;
 
         assert_bufs_equal(&file_contents, &read_data, None);
 
@@ -608,12 +609,12 @@ mod test {
     async fn test_get_content_summary(client: &Client) -> Result<()> {
         let mut file1 = client.create("/test", WriteOptions::default()).await?;
 
-        file1.write(vec![0, 1, 2, 3].into()).await?;
+        file1.write_bytes(vec![0, 1, 2, 3].into()).await?;
         file1.close().await?;
 
         let mut file2 = client.create("/test2", WriteOptions::default()).await?;
 
-        file2.write(vec![0, 1, 2, 3, 4, 5].into()).await?;
+        file2.write_bytes(vec![0, 1, 2, 3, 4, 5].into()).await?;
         file2.close().await?;
 
         client.mkdirs("/testdir", 0o755, true).await?;

--- a/rust/tests/test_integration.rs
+++ b/rust/tests/test_integration.rs
@@ -14,6 +14,8 @@ mod test {
     };
     use serial_test::serial;
     use std::collections::HashSet;
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use tokio::io::AsyncReadExt;
     use whoami::username;
 
     #[tokio::test]
@@ -330,6 +332,16 @@ mod test {
         let read_data = reader.read(reader.file_length()).await?;
 
         assert_bufs_equal(&file_contents, &read_data, None);
+
+        let mut reader = client.read("/newfile").await?;
+        let mut async_read_data = Vec::new();
+        reader.read_to_end(&mut async_read_data).await?;
+
+        assert_bufs_equal(
+            &file_contents,
+            &BytesMut::from(&async_read_data[..]),
+            Some("async read".to_string()),
+        );
 
         assert!(client.delete("/newfile", false).await.is_ok_and(|r| r));
 

--- a/rust/tests/test_read.rs
+++ b/rust/tests/test_read.rs
@@ -53,7 +53,7 @@ mod test {
 
         let mut file = client.create("/testfile", WriteOptions::default()).await?;
         for i in 0..TEST_FILE_INTS as i32 {
-            file.write(i.to_be_bytes().to_vec().into()).await?;
+            file.write_bytes(i.to_be_bytes().to_vec().into()).await?;
         }
         file.close().await?;
 
@@ -81,24 +81,24 @@ mod test {
         }
 
         // Positioned reads
-        let mut buf = reader.read(reader.file_length()).await?;
+        let mut buf = reader.read_bytes(reader.file_length()).await?;
         for i in 0..TEST_FILE_INTS as i32 {
             assert_eq!(buf.get_i32(), i);
         }
 
-        reader.seek(0);
+        reader.set_position(0);
 
         let mut buf = BytesMut::zeroed(reader.file_length());
-        assert_eq!(reader.read_buf(&mut buf).await?, reader.file_length());
+        assert_eq!(reader.read_into(&mut buf).await?, reader.file_length());
         for i in 0..TEST_FILE_INTS as i32 {
             assert_eq!(buf.get_i32(), i);
         }
 
         // Trying to read again should return nothing
-        assert!(reader.read(1).await?.is_empty());
+        assert!(reader.read_bytes(1).await?.is_empty());
 
         // Same with reading into a provided buffer
-        assert_eq!(reader.read_buf(&mut [0u8]).await?, 0);
+        assert_eq!(reader.read_into(&mut [0u8]).await?, 0);
 
         Ok(())
     }

--- a/rust/tests/test_read_resiliency.rs
+++ b/rust/tests/test_read_resiliency.rs
@@ -25,7 +25,7 @@ mod test {
 
         let mut file = client.create("/testfile", WriteOptions::default()).await?;
         for i in 0..TEST_FILE_INTS as i32 {
-            file.write(i.to_be_bytes().to_vec().into()).await?;
+            file.write_bytes(i.to_be_bytes().to_vec().into()).await?;
         }
         file.close().await?;
 
@@ -44,7 +44,7 @@ mod test {
             )
             .await?;
         for i in 0..TEST_FILE_INTS as i32 {
-            file.write(i.to_be_bytes().to_vec().into()).await?;
+            file.write_bytes(i.to_be_bytes().to_vec().into()).await?;
         }
         file.close().await?;
 

--- a/rust/tests/test_write.rs
+++ b/rust/tests/test_write.rs
@@ -79,7 +79,7 @@ mod test {
 
             let buf = data.freeze();
 
-            writer.write(buf.clone()).await?;
+            writer.write_bytes(buf.clone()).await?;
             writer.close().await?;
 
             assert_eq!(
@@ -88,7 +88,7 @@ mod test {
             );
 
             let mut reader = client.read("/newfile").await?;
-            let read_data = reader.read(reader.file_length()).await?;
+            let read_data = reader.read_bytes(reader.file_length()).await?;
 
             assert_bufs_equal(&buf, &read_data, Some(format!("for size {size_to_check}")));
         }
@@ -136,11 +136,11 @@ mod test {
             let buf = data.freeze();
 
             let mut writer = client.append("/newfile").await?;
-            writer.write(buf).await?;
+            writer.write_bytes(buf).await?;
             writer.close().await?;
 
             let mut reader = client.read("/newfile").await?;
-            let read_data = reader.read(reader.file_length()).await?;
+            let read_data = reader.read_bytes(reader.file_length()).await?;
 
             assert_bufs_equal(&file_contents, &read_data, None);
         }

--- a/rust/tests/test_write_resiliency.rs
+++ b/rust/tests/test_write_resiliency.rs
@@ -31,7 +31,7 @@ mod test {
 
         let mut writer = client.create(file, WriteOptions::default()).await?;
 
-        writer.write(Bytes::from(vec![0u8, 1, 2, 3])).await?;
+        writer.write_bytes(Bytes::from(vec![0u8, 1, 2, 3])).await?;
 
         // First client owns the lease, so can't append to the file
         assert!(client2.append("/testfile").await.is_err());
@@ -43,7 +43,7 @@ mod test {
         // writing.
         assert!(client2.append("/testfile").await.is_err());
 
-        writer.write(Bytes::from(vec![4u8, 5, 6, 7])).await?;
+        writer.write_bytes(Bytes::from(vec![4u8, 5, 6, 7])).await?;
 
         // This succeeding means the lease was renewed
         writer.close().await?;
@@ -114,7 +114,7 @@ mod test {
             WRITE_CONNECTION_FAULT_INJECTOR.store(true, Ordering::SeqCst);
 
             let data = data.freeze();
-            writer.write(data.clone()).await?;
+            writer.write_bytes(data.clone()).await?;
             writer.close().await?;
 
             let reader = client.read(&file).await?;
@@ -128,14 +128,14 @@ mod test {
                 )
                 .await?;
 
-            writer.write(data.slice(..bytes_to_write / 2)).await?;
+            writer.write_bytes(data.slice(..bytes_to_write / 2)).await?;
 
             // Give a little time for the packets to send
             tokio::time::sleep(Duration::from_millis(100)).await;
 
             WRITE_CONNECTION_FAULT_INJECTOR.store(true, Ordering::SeqCst);
 
-            writer.write(data.slice(bytes_to_write / 2..)).await?;
+            writer.write_bytes(data.slice(bytes_to_write / 2..)).await?;
             writer.close().await?;
 
             let reader = client.read(&file).await?;
@@ -151,7 +151,7 @@ mod test {
 
             *WRITE_REPLY_FAULT_INJECTOR.lock().unwrap() = Some(2);
 
-            writer.write(data.clone()).await?;
+            writer.write_bytes(data.clone()).await?;
             writer.close().await?;
 
             let reader = client.read(&file).await?;
@@ -165,14 +165,14 @@ mod test {
                 )
                 .await?;
 
-            writer.write(data.slice(..bytes_to_write / 2)).await?;
+            writer.write_bytes(data.slice(..bytes_to_write / 2)).await?;
 
             // Give a little time for the packets to send
             tokio::time::sleep(Duration::from_millis(100)).await;
 
             *WRITE_REPLY_FAULT_INJECTOR.lock().unwrap() = Some(2);
 
-            writer.write(data.slice(bytes_to_write / 2..)).await?;
+            writer.write_bytes(data.slice(bytes_to_write / 2..)).await?;
             writer.close().await?;
 
             let reader = client.read(&file).await?;
@@ -216,17 +216,19 @@ mod test {
             .create(file, WriteOptions::default().replication(3))
             .await?;
 
-        writer.write(data.slice(..bytes_to_write / 3)).await?;
+        writer.write_bytes(data.slice(..bytes_to_write / 3)).await?;
 
         WRITE_CONNECTION_FAULT_INJECTOR.store(true, Ordering::SeqCst);
         writer
-            .write(data.slice(bytes_to_write / 3..2 * bytes_to_write / 3))
+            .write_bytes(data.slice(bytes_to_write / 3..2 * bytes_to_write / 3))
             .await?;
         // Give a little time for the packets to send
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         WRITE_CONNECTION_FAULT_INJECTOR.store(true, Ordering::SeqCst);
-        writer.write(data.slice(2 * bytes_to_write / 3..)).await?;
+        writer
+            .write_bytes(data.slice(2 * bytes_to_write / 3..))
+            .await?;
         // Give a little time for the packets to send
         tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -275,7 +277,7 @@ mod test {
 
         WRITE_CONNECTION_FAULT_INJECTOR.store(true, Ordering::SeqCst);
 
-        writer.write(data.clone()).await?;
+        writer.write_bytes(data.clone()).await?;
         writer.close().await?;
 
         let reader = client.read(file).await?;
@@ -287,7 +289,7 @@ mod test {
 
         WRITE_CONNECTION_FAULT_INJECTOR.store(true, Ordering::SeqCst);
 
-        writer.write(data.slice(..bytes_to_write / 2)).await?;
+        writer.write_bytes(data.slice(..bytes_to_write / 2)).await?;
 
         // Give a little time for the packets to send
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -295,7 +297,7 @@ mod test {
         assert!(!WRITE_CONNECTION_FAULT_INJECTOR.load(Ordering::SeqCst));
         WRITE_CONNECTION_FAULT_INJECTOR.store(true, Ordering::SeqCst);
 
-        writer.write(data.slice(bytes_to_write / 2..)).await?;
+        writer.write_bytes(data.slice(bytes_to_write / 2..)).await?;
         writer.close().await?;
 
         // Give a little time for the packets to send
@@ -312,7 +314,7 @@ mod test {
 
         *WRITE_REPLY_FAULT_INJECTOR.lock().unwrap() = Some(2);
 
-        writer.write(data.clone()).await?;
+        writer.write_bytes(data.clone()).await?;
         writer.close().await?;
 
         let reader = client.read(file).await?;
@@ -322,14 +324,14 @@ mod test {
         let file = "/ec-3-2/striped_testfile4";
         let mut writer = client.create(file, WriteOptions::default()).await?;
 
-        writer.write(data.slice(..bytes_to_write / 2)).await?;
+        writer.write_bytes(data.slice(..bytes_to_write / 2)).await?;
 
         // Give a little time for the packets to send
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         *WRITE_REPLY_FAULT_INJECTOR.lock().unwrap() = Some(2);
 
-        writer.write(data.slice(bytes_to_write / 2..)).await?;
+        writer.write_bytes(data.slice(bytes_to_write / 2..)).await?;
         writer.close().await?;
 
         let reader = client.read(file).await?;
@@ -340,25 +342,25 @@ mod test {
         let mut writer = client.create(file, WriteOptions::default()).await?;
 
         WRITE_CONNECTION_FAULT_INJECTOR.store(true, Ordering::SeqCst);
-        writer.write(data.slice(..bytes_to_write / 2)).await?;
+        writer.write_bytes(data.slice(..bytes_to_write / 2)).await?;
         tokio::time::sleep(Duration::from_millis(100)).await;
         assert!(!WRITE_CONNECTION_FAULT_INJECTOR.load(Ordering::SeqCst));
 
         WRITE_CONNECTION_FAULT_INJECTOR.store(true, Ordering::SeqCst);
-        writer.write(data.slice(..bytes_to_write / 2)).await?;
+        writer.write_bytes(data.slice(..bytes_to_write / 2)).await?;
         tokio::time::sleep(Duration::from_millis(100)).await;
         assert!(!WRITE_CONNECTION_FAULT_INJECTOR.load(Ordering::SeqCst));
 
         // Third write. It won't fail yet because the sending of the data is asynchronous.
         // The failure will happen when the client tries to send the next block.
         WRITE_CONNECTION_FAULT_INJECTOR.store(true, Ordering::SeqCst);
-        writer.write(data.slice(..bytes_to_write / 2)).await?;
+        writer.write_bytes(data.slice(..bytes_to_write / 2)).await?;
         tokio::time::sleep(Duration::from_millis(100)).await;
         assert!(!WRITE_CONNECTION_FAULT_INJECTOR.load(Ordering::SeqCst));
 
         assert!(
             writer
-                .write(data.slice(..bytes_to_write / 2))
+                .write_bytes(data.slice(..bytes_to_write / 2))
                 .await
                 .is_err()
         );


### PR DESCRIPTION
Resolves #296 

Implements Read/Seek/Write traits for the sync FileReader/FileWriter, and implements AsyncRead and AsyncSeek for the async FileReader. AsyncWrite is not yet implemented because it is more complex to get right.

This also breaks some reader/writer APIs due to name conflicts with the traits and extension traits.