### PR TITLE
Support DataNode hostname config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Copy the `<INSTALL FOLDER>\MIT\Kerberos\bin\gssapi64.dll` file to a folder in %P
 The client will attempt to read Hadoop configs `core-site.xml` and `hdfs-site.xml` in the directories `$HADOOP_CONF_DIR` or if that doesn't exist, `$HADOOP_HOME/etc/hadoop`. Passing configs in run time is supported as well via `client::ClientBuilder`. Currently the supported configs that are used are:
 
 - `fs.defaultFS` - Client::default() support
-- `hadoop.security.authentication` - Enables Kerberos when set to a non-`simple` value
+- `hadoop.security.authentication` - Enables Kerberos
 - `dfs.ha.namenodes` - name service support
 - `dfs.namenode.rpc-address.*` - name service support
 - `dfs.user.home.dir.prefix` - Home directory prefix for HDFS paths

--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ Copy the `<INSTALL FOLDER>\MIT\Kerberos\bin\gssapi64.dll` file to a folder in %P
 The client will attempt to read Hadoop configs `core-site.xml` and `hdfs-site.xml` in the directories `$HADOOP_CONF_DIR` or if that doesn't exist, `$HADOOP_HOME/etc/hadoop`. Passing configs in run time is supported as well via `client::ClientBuilder`. Currently the supported configs that are used are:
 
 - `fs.defaultFS` - Client::default() support
+- `hadoop.security.authentication` - Enables Kerberos when set to a non-`simple` value
 - `dfs.ha.namenodes` - name service support
 - `dfs.namenode.rpc-address.*` - name service support
+- `dfs.user.home.dir.prefix` - Home directory prefix for HDFS paths
 - `dfs.client.failover.resolve-needed.*` - DNS based NameNode discovery
 - `dfs.client.failover.resolver.useFQDN.*` - DNS based NameNode discovery
 - `dfs.client.failover.random.order.*` - Randomize order of NameNodes to try
@@ -85,9 +87,12 @@ The client will attempt to read Hadoop configs `core-site.xml` and `hdfs-site.xm
   - `org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider`
   - `org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider`
   - `org.apache.hadoop.hdfs.server.namenode.ha.RouterObserverReadConfiguredFailoverProxyProvider`
+- `dfs.client.use.datanode.hostname` - Use DataNode hostnames instead of IP addresses for DataNode connections
 - `dfs.client.block.write.replace-datanode-on-failure.enable`
 - `dfs.client.block.write.replace-datanode-on-failure.policy`
 - `dfs.client.block.write.replace-datanode-on-failure.best-effort`
+- `dfs.data.transfer.protection` - Enables DataNode data transfer protection negotiation when set
+- `fs.viewfs.mounttable.*.homedir` - ViewFS home directory prefix
 - `fs.viewfs.mounttable.*.link.*` - ViewFS links
 - `fs.viewfs.mounttable.*.linkFallback` - ViewFS link fallback
 

--- a/rust/src/common/config.rs
+++ b/rust/src/common/config.rs
@@ -24,6 +24,7 @@ const DFS_CLIENT_FAILOVER_RESOLVER_USE_FQDN: &str = "dfs.client.failover.resolve
 const DFS_CLIENT_FAILOVER_RANDOM_ORDER: &str = "dfs.client.failover.random.order";
 const DFS_CLIENT_FAILOVER_PROXY_PROVIDER: &str = "dfs.client.failover.proxy.provider";
 const DFS_DATA_TRANSFER_PROTECTION: &str = "dfs.data.transfer.protection";
+const DFS_CLIENT_USE_DATANODE_HOSTNAME: &str = "dfs.client.use.datanode.hostname";
 
 const HADOOP_SECURITY_AUTHENTICATION: &str = "hadoop.security.authentication";
 
@@ -78,6 +79,10 @@ impl Configuration {
 
     pub(crate) fn data_transfer_protection_enabled(&self) -> bool {
         self.get(DFS_DATA_TRANSFER_PROTECTION).is_some()
+    }
+
+    pub(crate) fn use_datanode_hostname(&self) -> bool {
+        self.get_boolean(DFS_CLIENT_USE_DATANODE_HOSTNAME, false)
     }
 
     pub(crate) fn get_urls_for_nameservice(&self, nameservice: &str) -> Result<Vec<String>> {
@@ -397,7 +402,7 @@ mod test {
     use crate::common::config::DFS_CLIENT_FAILOVER_RESOLVER_USE_FQDN;
 
     use super::{
-        Configuration, DFS_CLIENT_FAILOVER_RESOLVE_NEEDED,
+        Configuration, DFS_CLIENT_FAILOVER_RESOLVE_NEEDED, DFS_CLIENT_USE_DATANODE_HOSTNAME,
         DFS_CLIENT_WRITE_REPLACE_DATANODE_ON_FAILURE_BEST_EFFORT_KEY,
         DFS_CLIENT_WRITE_REPLACE_DATANODE_ON_FAILURE_ENABLE_KEY,
         DFS_CLIENT_WRITE_REPLACE_DATANODE_ON_FAILURE_POLICY_KEY, EntityResolver,
@@ -634,6 +639,24 @@ mod test {
         };
         let policy = config.get_replace_datanode_on_failure_policy();
         assert!(!policy.is_best_effort());
+    }
+
+    #[test]
+    fn test_use_datanode_hostname_config() {
+        let config = Configuration {
+            map: HashMap::new(),
+        };
+        assert!(!config.use_datanode_hostname());
+
+        let config = Configuration {
+            map: [(
+                DFS_CLIENT_USE_DATANODE_HOSTNAME.to_string(),
+                "true".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+        };
+        assert!(config.use_datanode_hostname());
     }
 
     #[test]

--- a/rust/src/hdfs/block_reader.rs
+++ b/rust/src/hdfs/block_reader.rs
@@ -76,7 +76,7 @@ async fn connect_and_send(
 
     let mut remaining_attempts = 2;
     while remaining_attempts > 0 {
-        if let Some(mut conn) = DATANODE_CACHE.get(datanode_id) {
+        if let Some(mut conn) = DATANODE_CACHE.get(datanode_id, config) {
             let message = hdfs::OpReadBlockProto {
                 header: conn.build_header(block, Some(token.clone())),
                 offset,

--- a/rust/src/hdfs/connection.rs
+++ b/rust/src/hdfs/connection.rs
@@ -40,6 +40,15 @@ const CRC32C: Crc<u32, Table<16>> = Crc::<u32, Table<16>>::new(&CRC_32_ISCSI);
 pub(crate) static DATANODE_CACHE: Lazy<DatanodeConnectionCache> =
     Lazy::new(DatanodeConnectionCache::new);
 
+fn datanode_url(datanode_id: &DatanodeIdProto, config: &Configuration) -> String {
+    let host = if config.use_datanode_hostname() {
+        &datanode_id.host_name
+    } else {
+        &datanode_id.ip_addr
+    };
+    format!("{}:{}", host, datanode_id.xfer_port)
+}
+
 // Connect to a remote host and return a TcpStream with standard options we want
 async fn connect(addr: &str, handle: &Handle) -> Result<TcpStream> {
     let addr = addr.to_string();
@@ -590,7 +599,7 @@ impl DatanodeConnection {
         config: &Configuration,
         handle: &Handle,
     ) -> Result<Self> {
-        let url = format!("{}:{}", datanode_id.ip_addr, datanode_id.xfer_port);
+        let url = datanode_url(datanode_id, config);
         let stream = connect(&url, handle).await?;
 
         let sasl_connection = SaslDatanodeConnection::create(stream);
@@ -744,12 +753,16 @@ impl DatanodeConnectionCache {
         }
     }
 
-    pub(crate) fn get(&self, datanode_id: &hdfs::DatanodeIdProto) -> Option<DatanodeConnection> {
+    pub(crate) fn get(
+        &self,
+        datanode_id: &hdfs::DatanodeIdProto,
+        config: &Configuration,
+    ) -> Option<DatanodeConnection> {
         // Keep things simple and just expire cache entries when checking the cache. We could
         // move this to its own task but that will add a little more complexity.
         self.remove_expired();
 
-        let url = format!("{}:{}", datanode_id.ip_addr, datanode_id.xfer_port);
+        let url = datanode_url(datanode_id, config);
         let mut cache = self.cache.lock().unwrap();
 
         cache
@@ -787,9 +800,12 @@ mod test {
     use prost::Message;
     use tokio::sync::mpsc;
 
-    use crate::{hdfs::connection::MAX_PACKET_HEADER_SIZE, proto::hdfs, security::user::UserInfo};
+    use crate::{
+        common::config::Configuration, hdfs::connection::MAX_PACKET_HEADER_SIZE, proto::hdfs,
+        security::user::UserInfo,
+    };
 
-    use super::{AlignmentContext, RpcConnection};
+    use super::{AlignmentContext, RpcConnection, datanode_url};
 
     #[test]
     fn test_max_packet_header_size() {
@@ -800,6 +816,44 @@ mod test {
         };
         // Add 4 bytes for size of whole packet and 2 bytes for size of header
         assert_eq!(MAX_PACKET_HEADER_SIZE, header.encoded_len() + 4 + 2);
+    }
+
+    #[test]
+    fn test_datanode_url_uses_ip_address_by_default() {
+        let datanode_id = hdfs::DatanodeIdProto {
+            ip_addr: "127.0.0.1".to_string(),
+            host_name: "hdfs-datanode".to_string(),
+            xfer_port: 9866,
+            ..Default::default()
+        };
+        let config =
+            Configuration::new(Some("/tmp/hdfs-native-missing-conf".to_string()), None).unwrap();
+
+        assert_eq!(datanode_url(&datanode_id, &config), "127.0.0.1:9866");
+    }
+
+    #[test]
+    fn test_datanode_url_uses_hostname_when_configured() {
+        let datanode_id = hdfs::DatanodeIdProto {
+            ip_addr: "127.0.0.1".to_string(),
+            host_name: "hdfs-datanode".to_string(),
+            xfer_port: 9866,
+            ..Default::default()
+        };
+        let config = Configuration::new(
+            Some("/tmp/hdfs-native-missing-conf".to_string()),
+            Some(
+                [(
+                    "dfs.client.use.datanode.hostname".to_string(),
+                    "true".to_string(),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(datanode_url(&datanode_id, &config), "hdfs-datanode:9866");
     }
 
     fn encode_router_state(map: &HashMap<String, i64>) -> Vec<u8> {


### PR DESCRIPTION
## Summary

- Add support for `dfs.client.use.datanode.hostname` with the Hadoop default of `false`.
- Use the configured DataNode address consistently for new DataNode connections and the read connection cache key.
- Document additional supported client configuration keys in the README.

## Why

In containerized HDFS deployments, DataNodes can register `ip_addr=127.0.0.1` while `host_name` is the routable DNS name. Enabling `dfs.client.use.datanode.hostname=true` lets hdfs-native connect through the reported hostname instead of dialing loopback.

## Validation

- `cargo fmt --check`
- `cargo test`

Closes #302.