### PR TITLE
Retry NameNode failover with exponential backoff and remember the active on reads

### DIFF
--- a/rust/src/common/config.rs
+++ b/rust/src/common/config.rs
@@ -22,6 +22,9 @@ const HA_NAMENODE_RPC_ADDRESS_PREFIX: &str = "dfs.namenode.rpc-address";
 const DFS_CLIENT_FAILOVER_RESOLVE_NEEDED: &str = "dfs.client.failover.resolve-needed";
 const DFS_CLIENT_FAILOVER_RESOLVER_USE_FQDN: &str = "dfs.client.failover.resolver.useFQDN";
 const DFS_CLIENT_FAILOVER_RANDOM_ORDER: &str = "dfs.client.failover.random.order";
+const DFS_CLIENT_FAILOVER_MAX_ATTEMPTS: &str = "dfs.client.failover.max.attempts";
+const DFS_CLIENT_FAILOVER_SLEEP_BASE_MILLIS: &str = "dfs.client.failover.sleep.base.millis";
+const DFS_CLIENT_FAILOVER_SLEEP_MAX_MILLIS: &str = "dfs.client.failover.sleep.max.millis";
 const DFS_CLIENT_FAILOVER_PROXY_PROVIDER: &str = "dfs.client.failover.proxy.provider";
 const DFS_DATA_TRANSFER_PROTECTION: &str = "dfs.data.transfer.protection";
 const DFS_CLIENT_USE_DATANODE_HOSTNAME: &str = "dfs.client.use.datanode.hostname";
@@ -86,6 +89,24 @@ impl Configuration {
 
     pub(crate) fn use_datanode_hostname(&self) -> bool {
         self.get_boolean(DFS_CLIENT_USE_DATANODE_HOSTNAME, false)
+    }
+
+    fn get_u64(&self, key: &str, default: u64) -> u64 {
+        self.get(key)
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
+    }
+
+    pub(crate) fn failover_max_attempts(&self) -> u32 {
+        self.get_u64(DFS_CLIENT_FAILOVER_MAX_ATTEMPTS, 15) as u32
+    }
+
+    pub(crate) fn failover_sleep_base_millis(&self) -> u64 {
+        self.get_u64(DFS_CLIENT_FAILOVER_SLEEP_BASE_MILLIS, 500)
+    }
+
+    pub(crate) fn failover_sleep_max_millis(&self) -> u64 {
+        self.get_u64(DFS_CLIENT_FAILOVER_SLEEP_MAX_MILLIS, 15000)
     }
 
     pub(crate) fn get_urls_for_nameservice(&self, nameservice: &str) -> Result<Vec<String>> {

--- a/rust/src/hdfs/proxy.rs
+++ b/rust/src/hdfs/proxy.rs
@@ -2,10 +2,12 @@ use std::sync::{
     Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
 };
+use std::time::Duration;
 
 use bytes::Bytes;
 use log::{debug, warn};
 use prost::Message;
+use rand::RngExt;
 use tokio::runtime::Handle;
 use url::Url;
 
@@ -108,6 +110,9 @@ pub(crate) struct NameServiceProxy {
     find_observer: bool,
     current_observer: tokio::sync::Mutex<Option<usize>>,
     msynced: Option<tokio::sync::Mutex<bool>>,
+    failover_max_attempts: u32,
+    failover_sleep_base_millis: u64,
+    failover_sleep_max_millis: u64,
 }
 
 impl NameServiceProxy {
@@ -189,6 +194,9 @@ impl NameServiceProxy {
                 } else {
                     None
                 },
+                failover_max_attempts: config.failover_max_attempts(),
+                failover_sleep_base_millis: config.failover_sleep_base_millis(),
+                failover_sleep_max_millis: config.failover_sleep_max_millis(),
             })
         }
     }
@@ -297,22 +305,30 @@ impl NameServiceProxy {
                 Err(e) => warn!("Failed to call observer node, falling back to the active: {e:?}"),
             }
         }
-        let current_active = self.current_active.load(Ordering::SeqCst);
-        let rest = (0..self.proxy_connections.len()).filter(|i| *i != current_active);
-        let proxy_indices = [current_active].into_iter().chain(rest).collect::<Vec<_>>();
+        let mut proxy_index = self.current_active.load(Ordering::SeqCst);
+        let mut failovers: u32 = 0;
 
-        let mut attempts = 0;
         loop {
-            let proxy_index = proxy_indices[attempts];
-            let result = self.proxy_connections[proxy_index]
-                .call(method_name, message)
-                .await;
+            #[cfg(feature = "integration-test")]
+            let standby_injected =
+                crate::test::NAMENODE_STANDBY_FAULT_INJECTOR.load(Ordering::SeqCst);
+            #[cfg(not(feature = "integration-test"))]
+            let standby_injected = false;
+
+            let result = if standby_injected {
+                Err(HdfsError::RPCError(
+                    STANDBY_EXCEPTION.to_string(),
+                    "NameNode standby fault injection".to_string(),
+                ))
+            } else {
+                self.proxy_connections[proxy_index]
+                    .call(method_name, message)
+                    .await
+            };
 
             match result {
                 Ok(bytes) => {
-                    // We may have gotten a result from an observer node for a read, so only remember
-                    // the active if this is a write method
-                    if write {
+                    if write || !self.find_observer {
                         self.current_active.store(proxy_index, Ordering::SeqCst);
                     }
 
@@ -327,18 +343,31 @@ impl NameServiceProxy {
                 Err(HdfsError::RPCError(exception, msg)) if !Self::is_retriable(&exception) => {
                     return Err(Self::convert_rpc_error(exception, msg));
                 }
-                Err(_) if attempts >= self.proxy_connections.len() - 1 => return result,
-                // Retriable error, do nothing and try the next connection
-                Err(HdfsError::RPCError(exception, _))
-                | Err(HdfsError::FatalRPCError(exception, _))
-                    if Self::is_retriable(&exception) => {}
+                Err(e) if failovers >= self.failover_max_attempts => return Err(e),
                 Err(e) => {
-                    // Some other error, we will retry but log the error
-                    warn!("{:?}", e);
+                    match &e {
+                        // Retriable error, just try the next connection
+                        HdfsError::RPCError(exception, _)
+                        | HdfsError::FatalRPCError(exception, _)
+                            if Self::is_retriable(exception) => {}
+                        // Some other error, we will retry but log the error
+                        _ => warn!("{:?}", e),
+                    }
+
+                    failovers += 1;
+                    let num_proxies = self.proxy_connections.len() as u32;
+                    if failovers.is_multiple_of(num_proxies) {
+                        tokio::time::sleep(exponential_failover_sleep(
+                            self.failover_sleep_base_millis,
+                            self.failover_sleep_max_millis,
+                            failovers / num_proxies,
+                        ))
+                        .await;
+                    }
+
+                    proxy_index = (proxy_index + 1) % self.proxy_connections.len();
                 }
             }
-
-            attempts += 1;
         }
     }
 
@@ -349,6 +378,31 @@ impl NameServiceProxy {
                 HdfsError::AlreadyExists(msg)
             }
             _ => HdfsError::RPCError(exception, msg),
+        }
+    }
+}
+
+fn exponential_failover_sleep(base_millis: u64, max_millis: u64, failovers: u32) -> Duration {
+    let uncapped = base_millis.saturating_mul(1u64 << failovers.min(32));
+    let jittered = (uncapped as f64 * rand::rng().random_range(0.5..1.5)) as u64;
+    Duration::from_millis(jittered.min(max_millis))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exponential_failover_sleep() {
+        for _ in 0..100 {
+            let first_backoff = exponential_failover_sleep(500, 15000, 1);
+
+            assert!(first_backoff >= Duration::from_millis(500));
+            assert!(first_backoff <= Duration::from_millis(1500));
+            assert_eq!(
+                exponential_failover_sleep(500, 15000, 20),
+                Duration::from_millis(15000)
+            );
         }
     }
 }

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -1,6 +1,7 @@
 use std::sync::{Mutex, atomic::AtomicBool};
 
 pub static DATANODE_CONNECT_FAULT_INJECTOR: AtomicBool = AtomicBool::new(false);
+pub static NAMENODE_STANDBY_FAULT_INJECTOR: AtomicBool = AtomicBool::new(false);
 pub static DATANODE_READ_FAULT_INJECTOR: AtomicBool = AtomicBool::new(false);
 pub static EC_FAULT_INJECTOR: Mutex<Option<EcFaultInjection>> = Mutex::new(None);
 pub static WRITE_CONNECTION_FAULT_INJECTOR: AtomicBool = AtomicBool::new(false);

--- a/rust/tests/test_failover.rs
+++ b/rust/tests/test_failover.rs
@@ -1,0 +1,39 @@
+#[cfg(feature = "integration-test")]
+mod test {
+    use std::collections::HashSet;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use hdfs_native::{
+        Client, Result,
+        minidfs::{DfsFeatures, MiniDfs},
+        test::NAMENODE_STANDBY_FAULT_INJECTOR,
+    };
+    use serial_test::serial;
+
+    #[tokio::test]
+    #[serial]
+    async fn test_standby_failover_retry() -> Result<()> {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let _dfs = MiniDfs::with_features(&HashSet::from([DfsFeatures::HA]));
+        let client = Client::default();
+
+        client.mkdirs("/pre-failover", 0o755, true).await?;
+
+        NAMENODE_STANDBY_FAULT_INJECTOR.store(true, Ordering::SeqCst);
+
+        let write_during_failover = tokio::spawn({
+            let client = client.clone();
+            async move { client.mkdirs("/during-failover", 0o755, true).await }
+        });
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        NAMENODE_STANDBY_FAULT_INJECTOR.store(false, Ordering::SeqCst);
+
+        write_during_failover.await.unwrap()?;
+        assert!(client.get_file_info("/during-failover").await.is_ok());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

Two changes to `NameServiceProxy` to bring HA failover behavior in line with the Java client's `FailoverOnNetworkExceptionRetry`:

1. **Retry with backoff instead of a single sweep.** Currently `call_inner` tries each configured NameNode once and returns the error if the last one is retriable. During an actual HA transition every NameNode can report `StandbyException` for a few seconds, so a single sweep fails hard where the Java client rides it out. This PR retries up to `dfs.client.failover.max.attempts` (default 15) proxy switches. Every NameNode is tried once per round with no sleeping, so one-off requests against a healthy cluster are never delayed; between rounds the sleep grows exponentially from `dfs.client.failover.sleep.base.millis` (default 500ms), jittered 0.5-1.5x like the Java client's `calculateExponentialTime`, capped at `dfs.client.failover.sleep.max.millis` (default 15s).

2. **Remember the active NameNode on successful reads.** `current_active` was only updated on write calls (to avoid pinning an observer). Observer reads go through `call_observer`, so outside of observer mode a successful read identifies the active just as well as a write does. Without this, a read-only client whose first configured NameNode is the standby pays a standby round trip on every single call.

## Why

We hit this in production: a NameNode failover during a batch read surfaced as a hard `RPC error: org.apache.hadoop.ipc.StandbyException` where the equivalent Java-client job rode out the transition. Config keys and defaults match `hdfs-default.xml`.

## Testing

- New integration test (`test_standby_failover_retry`) using a new `NAMENODE_STANDBY_FAULT_INJECTOR`: every proxy answers `StandbyException` while a write is in flight, the injector clears 2 seconds later, and the write succeeds. Fails against the current single-sweep behavior.
- Unit test for the backoff computation (jitter bounds and cap).
- Existing lib tests pass; `cargo fmt --check` clean.
- Manually verified reads against a production kerberized HA cluster behave identically on the happy path.