### PR TITLE
Support per-client Kerberos credential caches

### DIFF
--- a/rust/c_src/gssapi_mit.h
+++ b/rust/c_src/gssapi_mit.h
@@ -1,6 +1,23 @@
 #include <gssapi/gssapi.h>
 #include <gssapi/gssapi_krb5.h>
 
+// RFC 5587 credential-store extension. Declare the small subset used here
+// directly because some platforms do not install gssapi_ext.h.
+typedef struct gss_key_value_element_struct {
+    const char *key;
+    const char *value;
+} gss_key_value_element_desc;
+
+typedef struct gss_key_value_set_struct {
+    size_t count;
+    gss_key_value_element_desc *elements;
+} gss_key_value_set_desc, *gss_key_value_set_t;
+typedef const gss_key_value_set_desc *gss_const_key_value_set_t;
+
+OM_uint32 gss_acquire_cred_from(
+    OM_uint32 *, gss_name_t, OM_uint32, gss_OID_set, gss_cred_usage_t,
+    gss_const_key_value_set_t, gss_cred_id_t *, gss_OID_set *, OM_uint32 *);
+
 const OM_uint32 _GSS_C_INDEFINITE = GSS_C_INDEFINITE;
 const OM_uint32 _GSS_C_CALLING_ERROR_MASK = GSS_C_CALLING_ERROR_MASK;
 const OM_uint32 _GSS_C_ROUTINE_ERROR_MASK = GSS_C_ROUTINE_ERROR_MASK;

--- a/rust/c_src/gssapi_mit.h
+++ b/rust/c_src/gssapi_mit.h
@@ -1,7 +1,7 @@
 #include <gssapi/gssapi.h>
 #include <gssapi/gssapi_krb5.h>
 
-// RFC 5587 credential-store extension. Declare the small subset used here
+// MIT Kerberos credential-store extension. Declare the small subset used here
 // directly because some platforms do not install gssapi_ext.h.
 typedef struct gss_key_value_element_struct {
     const char *key;
@@ -9,7 +9,7 @@ typedef struct gss_key_value_element_struct {
 } gss_key_value_element_desc;
 
 typedef struct gss_key_value_set_struct {
-    size_t count;
+    OM_uint32 count;
     gss_key_value_element_desc *elements;
 } gss_key_value_set_desc, *gss_key_value_set_t;
 typedef const gss_key_value_set_desc *gss_const_key_value_set_t;

--- a/rust/examples/kerberos_keytab_probe.rs
+++ b/rust/examples/kerberos_keytab_probe.rs
@@ -1,0 +1,43 @@
+use hdfs_native::{ClientBuilder, KerberosCredentials, WriteOptions};
+
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let url = args.next().expect("HDFS URL argument");
+    let config_dir = args.next().expect("Hadoop config directory argument");
+    let keytab = args.next().expect("keytab path argument");
+    let principal = args.next().expect("principal argument");
+    let path = args
+        .next()
+        .unwrap_or_else(|| "/tmp/hdfs-native-keytab-probe".to_string());
+    let payload = b"hdfs-native explicit keytab probe";
+
+    // Prove that authentication uses the credentials configured on this client.
+    unsafe { std::env::remove_var("KRB5CCNAME") };
+    let client = ClientBuilder::new()
+        .with_url(url)
+        .with_config_dir(config_dir)
+        .with_kerberos_credentials(KerberosCredentials::Keytab { principal, keytab })
+        .build()
+        .expect("build keytab-backed client");
+
+    let mut writer = client
+        .create(&path, WriteOptions::default().overwrite(true))
+        .await
+        .expect("create file through Kerberos RPC");
+    writer
+        .write_bytes(payload.to_vec().into())
+        .await
+        .expect("write through authenticated DataTransfer");
+    writer.close().await.expect("close file");
+
+    let reader = client.read(&path).await.expect("open file");
+    let bytes = reader
+        .read_range(0, reader.file_length())
+        .await
+        .expect("read through authenticated DataTransfer");
+    assert_eq!(bytes.as_ref(), payload);
+    assert!(client.delete(&path, false).await.expect("delete fixture"));
+
+    println!("explicit keytab integration passed");
+}

--- a/rust/examples/kerberos_keytab_probe.rs
+++ b/rust/examples/kerberos_keytab_probe.rs
@@ -1,4 +1,4 @@
-use hdfs_native::{ClientBuilder, KerberosCredentials, WriteOptions};
+use hdfs_native::{ClientBuilder, WriteOptions};
 
 #[tokio::main]
 async fn main() {
@@ -17,7 +17,7 @@ async fn main() {
     let client = ClientBuilder::new()
         .with_url(url)
         .with_config_dir(config_dir)
-        .with_kerberos_credentials(KerberosCredentials::Keytab { principal, keytab })
+        .with_kerberos_credentials(Some(principal), Some(keytab), None)
         .build()
         .expect("build keytab-backed client");
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -221,6 +221,20 @@ impl IORuntime {
 ///     .unwrap();
 /// ```
 ///
+/// Create a client that acquires credentials directly from a keytab:
+///
+/// ```rust,no_run
+/// # use hdfs_native::{ClientBuilder, KerberosCredentials};
+/// let client = ClientBuilder::new()
+///     .with_url("hdfs://namenode.example.com:9000")
+///     .with_kerberos_credentials(KerberosCredentials::Keytab {
+///         principal: "client@EXAMPLE.COM".into(),
+///         keytab: "/run/secrets/client.keytab".into(),
+///     })
+///     .build()
+///     .unwrap();
+/// ```
+///
 /// Create a new client with the environment variable
 ///
 /// ```rust,no_run
@@ -282,7 +296,7 @@ pub struct ClientBuilder {
     config_dir: Option<String>,
     runtime: Option<IORuntime>,
     user: Option<String>,
-    kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
+    kerberos_credentials: Option<crate::KerberosCredentials>,
 }
 
 impl ClientBuilder {
@@ -333,9 +347,11 @@ impl ClientBuilder {
     /// Set Kerberos credentials scoped to this client instance.
     ///
     /// When unset, Kerberos authentication continues to use the process-default
-    /// GSSAPI credential for backward compatibility.
+    /// GSSAPI credential for backward compatibility. Explicit credential stores
+    /// require a runtime GSSAPI implementation that exports
+    /// `gss_acquire_cred_from` (such as MIT Kerberos).
     pub fn with_kerberos_credentials(mut self, credentials: crate::KerberosCredentials) -> Self {
-        self.kerberos_credentials = Some(Arc::new(credentials));
+        self.kerberos_credentials = Some(credentials);
         self
     }
 
@@ -353,7 +369,9 @@ impl ClientBuilder {
             config,
             self.runtime,
             self.user,
-            self.kerberos_credentials,
+            self.kerberos_credentials
+                .map(crate::KerberosCredentials::resolve)
+                .map(Arc::new),
         )
     }
 }
@@ -417,7 +435,7 @@ impl Client {
         config: Configuration,
         rt: Option<IORuntime>,
         user: Option<String>,
-        kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
+        kerberos_credentials: Option<Arc<crate::security::ResolvedKerberosCredentials>>,
     ) -> Result<Self> {
         let resolved_url = if !url.has_host() {
             let default_url = Self::default_fs(&config)?;
@@ -504,7 +522,7 @@ impl Client {
         config: Arc<Configuration>,
         handle: Handle,
         effective_user: Option<String>,
-        kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
+        kerberos_credentials: Option<Arc<crate::security::ResolvedKerberosCredentials>>,
         home_dir: String,
     ) -> Result<MountTable> {
         let mut mounts: Vec<MountLink> = Vec::new();

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -224,13 +224,14 @@ impl IORuntime {
 /// Create a client that acquires credentials directly from a keytab:
 ///
 /// ```rust,no_run
-/// # use hdfs_native::{ClientBuilder, KerberosCredentials};
+/// # use hdfs_native::ClientBuilder;
 /// let client = ClientBuilder::new()
 ///     .with_url("hdfs://namenode.example.com:9000")
-///     .with_kerberos_credentials(KerberosCredentials::Keytab {
-///         principal: "client@EXAMPLE.COM".into(),
-///         keytab: "/run/secrets/client.keytab".into(),
-///     })
+///     .with_kerberos_credentials(
+///         Some("client@EXAMPLE.COM".into()),
+///         Some("/run/secrets/client.keytab".into()),
+///         None,
+///     )
 ///     .build()
 ///     .unwrap();
 /// ```
@@ -279,13 +280,14 @@ impl IORuntime {
 /// Create a client with an explicit Kerberos credential cache:
 ///
 /// ```rust,no_run
-/// # use hdfs_native::{ClientBuilder, KerberosCredentials};
+/// # use hdfs_native::ClientBuilder;
 /// let client = ClientBuilder::new()
 ///     .with_url("hdfs://namenode.example.com:9000")
-///     .with_kerberos_credentials(KerberosCredentials::CredentialCache {
-///         principal: "client@EXAMPLE.COM".into(),
-///         cache: "FILE:/run/krb5/client.ccache".into(),
-///     })
+///     .with_kerberos_credentials(
+///         Some("client@EXAMPLE.COM".into()),
+///         None,
+///         Some("FILE:/run/krb5/client.ccache".into()),
+///     )
 ///     .build()
 ///     .unwrap();
 /// ```
@@ -296,7 +298,7 @@ pub struct ClientBuilder {
     config_dir: Option<String>,
     runtime: Option<IORuntime>,
     user: Option<String>,
-    kerberos_credentials: Option<crate::KerberosCredentials>,
+    kerberos_credentials: Option<crate::security::KerberosCredentials>,
 }
 
 impl ClientBuilder {
@@ -347,11 +349,22 @@ impl ClientBuilder {
     /// Set Kerberos credentials scoped to this client instance.
     ///
     /// When unset, Kerberos authentication continues to use the process-default
-    /// GSSAPI credential for backward compatibility. Explicit credential stores
-    /// require a runtime GSSAPI implementation that exports
+    /// GSSAPI credential for backward compatibility. `keytab` and `cache` are
+    /// independent and may be provided together. A keytab without a cache gets
+    /// a private in-memory cache. Explicit credential stores require a runtime
+    /// GSSAPI implementation that exports
     /// `gss_acquire_cred_from` (such as MIT Kerberos).
-    pub fn with_kerberos_credentials(mut self, credentials: crate::KerberosCredentials) -> Self {
-        self.kerberos_credentials = Some(credentials);
+    pub fn with_kerberos_credentials(
+        mut self,
+        principal: Option<String>,
+        keytab: Option<String>,
+        cache: Option<String>,
+    ) -> Self {
+        self.kerberos_credentials = Some(crate::security::KerberosCredentials {
+            principal,
+            keytab,
+            cache,
+        });
         self
     }
 
@@ -370,7 +383,7 @@ impl ClientBuilder {
             self.runtime,
             self.user,
             self.kerberos_credentials
-                .map(crate::KerberosCredentials::resolve)
+                .and_then(crate::security::KerberosCredentials::resolve)
                 .map(Arc::new),
         )
     }
@@ -454,9 +467,11 @@ impl Client {
         let rt_holder = RuntimeHolder::new(rt);
 
         let user_info = if config.security_enabled()
-            && let Some(credentials) = kerberos_credentials.as_deref()
+            && let Some(principal) = kerberos_credentials
+                .as_deref()
+                .and_then(|credentials| credentials.principal.as_deref())
         {
-            User::get_user_info_from_principal(credentials.principal(), user.clone())
+            User::get_user_info_from_principal(principal, user.clone())
         } else {
             User::get_user_info(user.clone(), config.security_enabled())
         };
@@ -1502,7 +1517,6 @@ mod test {
     use url::Url;
 
     use crate::{
-        KerberosCredentials,
         client::ClientBuilder,
         common::config::Configuration,
         hdfs::{protocol::NamenodeProtocol, proxy::NameServiceProxy},
@@ -1707,10 +1721,11 @@ mod test {
         let client = ClientBuilder::new()
             .with_url("hdfs://127.0.0.1:9000")
             .with_config([("hadoop.security.authentication", "kerberos")])
-            .with_kerberos_credentials(KerberosCredentials::CredentialCache {
-                principal: "alice@EXAMPLE.COM".to_string(),
-                cache: "FILE:/run/krb5/alice.ccache".to_string(),
-            })
+            .with_kerberos_credentials(
+                Some("alice@EXAMPLE.COM".to_string()),
+                None,
+                Some("FILE:/run/krb5/alice.ccache".to_string()),
+            )
             .build()
             .unwrap();
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -261,6 +261,20 @@ impl IORuntime {
 ///     .build()
 ///     .unwrap();
 /// ```
+///
+/// Create a client with an explicit Kerberos credential cache:
+///
+/// ```rust,no_run
+/// # use hdfs_native::{ClientBuilder, KerberosCredentials};
+/// let client = ClientBuilder::new()
+///     .with_url("hdfs://namenode.example.com:9000")
+///     .with_kerberos_credentials(KerberosCredentials::CredentialCache {
+///         principal: "client@EXAMPLE.COM".into(),
+///         cache: "FILE:/run/krb5/client.ccache".into(),
+///     })
+///     .build()
+///     .unwrap();
+/// ```
 #[derive(Default)]
 pub struct ClientBuilder {
     url: Option<String>,
@@ -268,6 +282,7 @@ pub struct ClientBuilder {
     config_dir: Option<String>,
     runtime: Option<IORuntime>,
     user: Option<String>,
+    kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
 }
 
 impl ClientBuilder {
@@ -315,6 +330,15 @@ impl ClientBuilder {
         self
     }
 
+    /// Set Kerberos credentials scoped to this client instance.
+    ///
+    /// When unset, Kerberos authentication continues to use the process-default
+    /// GSSAPI credential for backward compatibility.
+    pub fn with_kerberos_credentials(mut self, credentials: crate::KerberosCredentials) -> Self {
+        self.kerberos_credentials = Some(Arc::new(credentials));
+        self
+    }
+
     /// Create the [Client] instance from the provided settings
     pub fn build(self) -> Result<Client> {
         let config = Configuration::new(self.config_dir, self.config)?;
@@ -324,7 +348,13 @@ impl ClientBuilder {
             Client::default_fs(&config)?
         };
 
-        Client::build(&url, config, self.runtime, self.user)
+        Client::build(
+            &url,
+            config,
+            self.runtime,
+            self.user,
+            self.kerberos_credentials,
+        )
     }
 }
 
@@ -387,6 +417,7 @@ impl Client {
         config: Configuration,
         rt: Option<IORuntime>,
         user: Option<String>,
+        kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
     ) -> Result<Self> {
         let resolved_url = if !url.has_host() {
             let default_url = Self::default_fs(&config)?;
@@ -404,7 +435,13 @@ impl Client {
 
         let rt_holder = RuntimeHolder::new(rt);
 
-        let user_info = User::get_user_info(user.clone(), config.security_enabled());
+        let user_info = if config.security_enabled()
+            && let Some(credentials) = kerberos_credentials.as_deref()
+        {
+            User::get_user_info_from_principal(credentials.principal(), user.clone())
+        } else {
+            User::get_user_info(user.clone(), config.security_enabled())
+        };
         let username = user_info
             .effective_user
             .as_deref()
@@ -424,6 +461,7 @@ impl Client {
                     Arc::clone(&config),
                     rt_holder.get_handle(),
                     user.clone(),
+                    kerberos_credentials.clone(),
                 )?;
                 let protocol = Arc::new(NamenodeProtocol::new(proxy, rt_holder.get_handle()));
 
@@ -439,6 +477,7 @@ impl Client {
                 Arc::clone(&config),
                 rt_holder.get_handle(),
                 user.clone(),
+                kerberos_credentials,
                 home_dir,
             )?,
             _ => {
@@ -465,6 +504,7 @@ impl Client {
         config: Arc<Configuration>,
         handle: Handle,
         effective_user: Option<String>,
+        kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
         home_dir: String,
     ) -> Result<MountTable> {
         let mut mounts: Vec<MountLink> = Vec::new();
@@ -487,6 +527,7 @@ impl Client {
                 Arc::clone(&config),
                 handle.clone(),
                 effective_user.clone(),
+                kerberos_credentials.clone(),
             )?;
             let protocol = Arc::new(NamenodeProtocol::new(proxy, handle.clone()));
 
@@ -1443,6 +1484,7 @@ mod test {
     use url::Url;
 
     use crate::{
+        KerberosCredentials,
         client::ClientBuilder,
         common::config::Configuration,
         hdfs::{protocol::NamenodeProtocol, proxy::NameServiceProxy},
@@ -1457,6 +1499,7 @@ mod test {
             &Url::parse(url).unwrap(),
             Arc::new(Configuration::new(None, None).unwrap()),
             RT.handle().clone(),
+            None,
             None,
         )
         .unwrap();
@@ -1634,6 +1677,22 @@ mod test {
         let client = ClientBuilder::new()
             .with_url("hdfs://127.0.0.1:9000")
             .with_user("alice")
+            .build()
+            .unwrap();
+
+        let (_, resolved) = client.mount_table.resolve("file");
+        assert_eq!(resolved, "/user/alice/file");
+    }
+
+    #[test]
+    fn test_kerberos_credentials_set_principal_home_dir() {
+        let client = ClientBuilder::new()
+            .with_url("hdfs://127.0.0.1:9000")
+            .with_config([("hadoop.security.authentication", "kerberos")])
+            .with_kerberos_credentials(KerberosCredentials::CredentialCache {
+                principal: "alice@EXAMPLE.COM".to_string(),
+                cache: "FILE:/run/krb5/alice.ccache".to_string(),
+            })
             .build()
             .unwrap();
 

--- a/rust/src/hdfs/connection.rs
+++ b/rust/src/hdfs/connection.rs
@@ -139,7 +139,7 @@ impl RpcConnection {
         alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
         nameservice: Option<&str>,
         effective_user: Option<String>,
-        kerberos_credentials: Option<&crate::KerberosCredentials>,
+        kerberos_credentials: Option<&crate::security::ResolvedKerberosCredentials>,
         config: &Configuration,
         handle: &Handle,
     ) -> Result<Self> {

--- a/rust/src/hdfs/connection.rs
+++ b/rust/src/hdfs/connection.rs
@@ -139,6 +139,7 @@ impl RpcConnection {
         alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
         nameservice: Option<&str>,
         effective_user: Option<String>,
+        kerberos_credentials: Option<&crate::KerberosCredentials>,
         config: &Configuration,
         handle: &Handle,
     ) -> Result<Self> {
@@ -162,8 +163,14 @@ impl RpcConnection {
         let service = nameservice
             .map(|ns| format!("ha-hdfs:{ns}"))
             .unwrap_or(url.to_string());
-        let (user_info, reader, writer) =
-            negotiate_sasl_session(stream, &service, config, effective_user).await?;
+        let (user_info, reader, writer) = negotiate_sasl_session(
+            stream,
+            &service,
+            config,
+            effective_user,
+            kerberos_credentials,
+        )
+        .await?;
         let (sender, receiver) = mpsc::channel::<Vec<u8>>(1000);
 
         let mut conn = RpcConnection {

--- a/rust/src/hdfs/proxy.rs
+++ b/rust/src/hdfs/proxy.rs
@@ -31,7 +31,7 @@ struct ProxyConnection {
     alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
     nameservice: Option<String>,
     effective_user: Option<String>,
-    kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
+    kerberos_credentials: Option<Arc<crate::security::ResolvedKerberosCredentials>>,
     config: Arc<Configuration>,
     handle: Handle,
 }
@@ -42,7 +42,7 @@ impl ProxyConnection {
         alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
         nameservice: Option<String>,
         effective_user: Option<String>,
-        kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
+        kerberos_credentials: Option<Arc<crate::security::ResolvedKerberosCredentials>>,
         config: Arc<Configuration>,
         handle: Handle,
     ) -> Self {
@@ -127,7 +127,7 @@ impl NameServiceProxy {
         config: Arc<Configuration>,
         handle: Handle,
         effective_user: Option<String>,
-        kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
+        kerberos_credentials: Option<Arc<crate::security::ResolvedKerberosCredentials>>,
     ) -> Result<Self> {
         let host = nameservice.host_str().ok_or(HdfsError::InvalidArgument(
             "No host for name service".to_string(),

--- a/rust/src/hdfs/proxy.rs
+++ b/rust/src/hdfs/proxy.rs
@@ -31,6 +31,7 @@ struct ProxyConnection {
     alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
     nameservice: Option<String>,
     effective_user: Option<String>,
+    kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
     config: Arc<Configuration>,
     handle: Handle,
 }
@@ -41,6 +42,7 @@ impl ProxyConnection {
         alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
         nameservice: Option<String>,
         effective_user: Option<String>,
+        kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
         config: Arc<Configuration>,
         handle: Handle,
     ) -> Self {
@@ -50,6 +52,7 @@ impl ProxyConnection {
             alignment_context,
             nameservice,
             effective_user,
+            kerberos_credentials,
             config,
             handle,
         }
@@ -68,6 +71,7 @@ impl ProxyConnection {
                                 self.alignment_context.clone(),
                                 self.nameservice.as_deref(),
                                 self.effective_user.clone(),
+                                self.kerberos_credentials.as_deref(),
                                 &self.config,
                                 &self.handle,
                             )
@@ -123,6 +127,7 @@ impl NameServiceProxy {
         config: Arc<Configuration>,
         handle: Handle,
         effective_user: Option<String>,
+        kerberos_credentials: Option<Arc<crate::KerberosCredentials>>,
     ) -> Result<Self> {
         let host = nameservice.host_str().ok_or(HdfsError::InvalidArgument(
             "No host for name service".to_string(),
@@ -158,6 +163,7 @@ impl NameServiceProxy {
                 alignment_context,
                 None,
                 effective_user,
+                kerberos_credentials,
                 Arc::clone(&config),
                 handle,
             )]
@@ -172,6 +178,7 @@ impl NameServiceProxy {
                         alignment_context.clone(),
                         Some(host.to_string()),
                         effective_user.clone(),
+                        kerberos_credentials.clone(),
                         Arc::clone(&config),
                         handle.clone(),
                     )

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -64,7 +64,6 @@ pub use client::WriteOptions;
 pub use client::{Client, ClientBuilder};
 pub use error::HdfsError;
 pub use error::Result;
-pub use security::KerberosCredentials;
 
 // Module for testing hooks into non-test code
 #[cfg(feature = "integration-test")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -64,6 +64,7 @@ pub use client::WriteOptions;
 pub use client::{Client, ClientBuilder};
 pub use error::HdfsError;
 pub use error::Result;
+pub use security::KerberosCredentials;
 
 // Module for testing hooks into non-test code
 #[cfg(feature = "integration-test")]

--- a/rust/src/security/gssapi.rs
+++ b/rust/src/security/gssapi.rs
@@ -263,24 +263,48 @@ impl GssCred {
         Ok(Self { cred })
     }
 
-    fn acquire_from_cache(principal: &str, cache: &str) -> crate::Result<Self> {
+    fn acquire(credentials: &crate::security::ResolvedKerberosCredentials) -> crate::Result<Self> {
         if libgssapi()?.gss_acquire_cred_from.is_err() {
             return Err(HdfsError::OperationFailed(
                 "The installed GSSAPI library does not support credential stores".to_string(),
             ));
         }
-        let desired_name = GssName::with_principal(principal)?;
-        let key = CString::new("ccache").expect("static string does not contain NUL");
-        let value = CString::new(cache).map_err(|_| {
+        let desired_name = GssName::with_principal(credentials.principal())?;
+        let ccache_key = CString::new("ccache").expect("static string does not contain NUL");
+        let keytab_key = CString::new("client_keytab").expect("static string does not contain NUL");
+        let (ccache, keytab) = match credentials {
+            crate::security::ResolvedKerberosCredentials::CredentialCache { cache, .. } => {
+                (cache, None)
+            }
+            crate::security::ResolvedKerberosCredentials::Keytab { keytab, cache, .. } => {
+                (cache, Some(keytab))
+            }
+        };
+        let ccache = CString::new(ccache.as_str()).map_err(|_| {
             HdfsError::InvalidArgument("Kerberos credential cache contains a NUL byte".to_string())
         })?;
-        let mut element = bindings::gss_key_value_element_desc {
-            key: key.as_ptr(),
-            value: value.as_ptr(),
-        };
+        let keytab = keytab
+            .map(|keytab| {
+                CString::new(keytab.as_str()).map_err(|_| {
+                    HdfsError::InvalidArgument(
+                        "Kerberos keytab path contains a NUL byte".to_string(),
+                    )
+                })
+            })
+            .transpose()?;
+        let mut elements = vec![bindings::gss_key_value_element_desc {
+            key: ccache_key.as_ptr(),
+            value: ccache.as_ptr(),
+        }];
+        if let Some(keytab) = keytab.as_ref() {
+            elements.push(bindings::gss_key_value_element_desc {
+                key: keytab_key.as_ptr(),
+                value: keytab.as_ptr(),
+            });
+        }
         let store = bindings::gss_key_value_set_desc {
-            count: 1,
-            elements: &mut element,
+            count: elements.len() as bindings::OM_uint32,
+            elements: elements.as_mut_ptr(),
         };
         let mut minor = 0;
         let mut cred = ptr::null_mut();
@@ -621,15 +645,13 @@ impl GssapiSession {
         service: &str,
         hostname: &str,
         effective_user: Option<String>,
-        kerberos_credentials: Option<&crate::KerberosCredentials>,
+        kerberos_credentials: Option<&crate::security::ResolvedKerberosCredentials>,
     ) -> crate::Result<Self> {
         let targ_name = format!("{service}@{hostname}");
 
         let target = GssName::with_target(&targ_name)?;
         let credential = match kerberos_credentials {
-            Some(crate::KerberosCredentials::CredentialCache { principal, cache }) => {
-                Some(GssCred::acquire_from_cache(principal, cache)?)
-            }
+            Some(credentials) => Some(GssCred::acquire(credentials)?),
             None => None,
         };
         let state = GssapiState::Pending(GssClientCtx::with_credential(target, credential));

--- a/rust/src/security/gssapi.rs
+++ b/rust/src/security/gssapi.rs
@@ -264,38 +264,67 @@ impl GssCred {
     }
 
     fn acquire(credentials: &crate::security::ResolvedKerberosCredentials) -> crate::Result<Self> {
+        let mut desired_name = credentials
+            .principal
+            .as_deref()
+            .map(GssName::with_principal)
+            .transpose()?;
+        if credentials.keytab.is_none() && credentials.cache.is_none() {
+            let mut minor = 0;
+            let mut cred = ptr::null_mut();
+            let major = unsafe {
+                libgssapi()?.gss_acquire_cred(
+                    &mut minor,
+                    desired_name
+                        .as_mut()
+                        .map_or(ptr::null_mut(), |name| name.name),
+                    bindings::_GSS_C_INDEFINITE,
+                    ptr::null_mut(),
+                    bindings::GSS_C_INITIATE as bindings::gss_cred_usage_t,
+                    &mut cred,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                )
+            };
+            check_gss_ok(major, minor)?;
+            return Ok(Self { cred });
+        }
         if libgssapi()?.gss_acquire_cred_from.is_err() {
             return Err(HdfsError::OperationFailed(
                 "The installed GSSAPI library does not support credential stores".to_string(),
             ));
         }
-        let desired_name = GssName::with_principal(credentials.principal())?;
         let ccache_key = CString::new("ccache").expect("static string does not contain NUL");
         let keytab_key = CString::new("client_keytab").expect("static string does not contain NUL");
-        let (ccache, keytab) = match credentials {
-            crate::security::ResolvedKerberosCredentials::CredentialCache { cache, .. } => {
-                (cache, None)
-            }
-            crate::security::ResolvedKerberosCredentials::Keytab { keytab, cache, .. } => {
-                (cache, Some(keytab))
-            }
-        };
-        let ccache = CString::new(ccache.as_str()).map_err(|_| {
-            HdfsError::InvalidArgument("Kerberos credential cache contains a NUL byte".to_string())
-        })?;
-        let keytab = keytab
+        let ccache = credentials
+            .cache
+            .as_deref()
+            .map(|cache| {
+                CString::new(cache).map_err(|_| {
+                    HdfsError::InvalidArgument(
+                        "Kerberos credential cache contains a NUL byte".to_string(),
+                    )
+                })
+            })
+            .transpose()?;
+        let keytab = credentials
+            .keytab
+            .as_deref()
             .map(|keytab| {
-                CString::new(keytab.as_str()).map_err(|_| {
+                CString::new(keytab).map_err(|_| {
                     HdfsError::InvalidArgument(
                         "Kerberos keytab path contains a NUL byte".to_string(),
                     )
                 })
             })
             .transpose()?;
-        let mut elements = vec![bindings::gss_key_value_element_desc {
-            key: ccache_key.as_ptr(),
-            value: ccache.as_ptr(),
-        }];
+        let mut elements = Vec::new();
+        if let Some(ccache) = ccache.as_ref() {
+            elements.push(bindings::gss_key_value_element_desc {
+                key: ccache_key.as_ptr(),
+                value: ccache.as_ptr(),
+            });
+        }
         if let Some(keytab) = keytab.as_ref() {
             elements.push(bindings::gss_key_value_element_desc {
                 key: keytab_key.as_ptr(),
@@ -311,7 +340,9 @@ impl GssCred {
         let major = unsafe {
             libgssapi()?.gss_acquire_cred_from(
                 &mut minor,
-                desired_name.name,
+                desired_name
+                    .as_mut()
+                    .map_or(ptr::null_mut(), |name| name.name),
                 bindings::_GSS_C_INDEFINITE,
                 ptr::null_mut(),
                 bindings::GSS_C_INITIATE as bindings::gss_cred_usage_t,

--- a/rust/src/security/gssapi.rs
+++ b/rust/src/security/gssapi.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use log::warn;
 use once_cell::sync::Lazy;
+use std::ffi::CString;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::os::raw::c_void;
@@ -162,16 +163,33 @@ impl GssName {
     }
 
     fn with_target(target_name: &str) -> crate::Result<Self> {
+        Self::import(target_name, unsafe {
+            *libgssapi()?.GSS_C_NT_HOSTBASED_SERVICE()
+        })
+    }
+
+    fn with_principal(principal: &str) -> crate::Result<Self> {
+        if libgssapi()?.GSS_KRB5_NT_PRINCIPAL_NAME.is_err() {
+            return Err(HdfsError::OperationFailed(
+                "The installed GSSAPI library cannot import Kerberos principal names".to_string(),
+            ));
+        }
+        Self::import(principal, unsafe {
+            *libgssapi()?.GSS_KRB5_NT_PRINCIPAL_NAME() as bindings::gss_OID
+        })
+    }
+
+    fn import(name_value: &str, name_type: bindings::gss_OID) -> crate::Result<Self> {
         let mut minor = bindings::GSS_S_COMPLETE;
         let mut name = ptr::null_mut::<bindings::gss_name_struct>();
 
-        let mut name_buf = GssBuf::from(target_name);
+        let mut name_buf = GssBuf::from(name_value);
 
         let major = unsafe {
             libgssapi()?.gss_import_name(
                 &mut minor,
                 name_buf.as_ptr(),
-                *libgssapi()?.GSS_C_NT_HOSTBASED_SERVICE(),
+                name_type,
                 &mut name as *mut bindings::gss_name_t,
             )
         };
@@ -245,6 +263,44 @@ impl GssCred {
         Ok(Self { cred })
     }
 
+    fn acquire_from_cache(principal: &str, cache: &str) -> crate::Result<Self> {
+        if libgssapi()?.gss_acquire_cred_from.is_err() {
+            return Err(HdfsError::OperationFailed(
+                "The installed GSSAPI library does not support credential stores".to_string(),
+            ));
+        }
+        let desired_name = GssName::with_principal(principal)?;
+        let key = CString::new("ccache").expect("static string does not contain NUL");
+        let value = CString::new(cache).map_err(|_| {
+            HdfsError::InvalidArgument("Kerberos credential cache contains a NUL byte".to_string())
+        })?;
+        let mut element = bindings::gss_key_value_element_desc {
+            key: key.as_ptr(),
+            value: value.as_ptr(),
+        };
+        let store = bindings::gss_key_value_set_desc {
+            count: 1,
+            elements: &mut element,
+        };
+        let mut minor = 0;
+        let mut cred = ptr::null_mut();
+        let major = unsafe {
+            libgssapi()?.gss_acquire_cred_from(
+                &mut minor,
+                desired_name.name,
+                bindings::_GSS_C_INDEFINITE,
+                ptr::null_mut(),
+                bindings::GSS_C_INITIATE as bindings::gss_cred_usage_t,
+                &store,
+                &mut cred,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+        };
+        check_gss_ok(major, minor)?;
+        Ok(Self { cred })
+    }
+
     fn name(&self) -> crate::Result<GssName> {
         let mut minor = 0;
         let mut name = ptr::null_mut::<bindings::gss_name_struct>();
@@ -295,17 +351,27 @@ struct GssClientCtx {
     target: GssName,
     mech: GssMech,
     flags: u32,
+    credential: Option<GssCred>,
 }
 
 unsafe impl Send for GssClientCtx {}
 unsafe impl Sync for GssClientCtx {}
 
 impl GssClientCtx {
-    fn new(target: GssName) -> Self {
-        Self::with_mech(target, GssMech::Krb5)
+    fn with_credential(target: GssName, credential: Option<GssCred>) -> Self {
+        Self::with_mech_and_credential(target, GssMech::Krb5, credential)
     }
 
+    #[cfg(feature = "kms")]
     fn with_mech(target: GssName, mech: GssMech) -> Self {
+        Self::with_mech_and_credential(target, mech, None)
+    }
+
+    fn with_mech_and_credential(
+        target: GssName,
+        mech: GssMech,
+        credential: Option<GssCred>,
+    ) -> Self {
         // Hadoop IPC SASL uses GSSAPI/Kerberos and historically requests credential
         // delegation. SPNEGO over HTTP (KMS) does not need delegation, and the
         // delegated TGT bloats the SPNEGO token to the point where it can exceed
@@ -336,6 +402,7 @@ impl GssClientCtx {
             target,
             mech,
             flags,
+            credential,
         }
     }
 
@@ -367,7 +434,10 @@ impl GssClientCtx {
         let major = unsafe {
             libgssapi()?.gss_init_sec_context(
                 &mut minor,
-                ptr::null_mut(),
+                self.credential
+                    .as_ref()
+                    .map(|credential| credential.cred)
+                    .unwrap_or(ptr::null_mut()),
                 &mut self.ctx as *mut bindings::gss_ctx_id_t,
                 self.target.name,
                 mech_oid,
@@ -551,11 +621,18 @@ impl GssapiSession {
         service: &str,
         hostname: &str,
         effective_user: Option<String>,
+        kerberos_credentials: Option<&crate::KerberosCredentials>,
     ) -> crate::Result<Self> {
         let targ_name = format!("{service}@{hostname}");
 
         let target = GssName::with_target(&targ_name)?;
-        let state = GssapiState::Pending(GssClientCtx::new(target));
+        let credential = match kerberos_credentials {
+            Some(crate::KerberosCredentials::CredentialCache { principal, cache }) => {
+                Some(GssCred::acquire_from_cache(principal, cache)?)
+            }
+            None => None,
+        };
+        let state = GssapiState::Pending(GssClientCtx::with_credential(target, credential));
         Ok(Self {
             state,
             effective_user,

--- a/rust/src/security/gssapi_bindings.rs
+++ b/rust/src/security/gssapi_bindings.rs
@@ -84,7 +84,7 @@ pub type gss_key_value_element_desc = gss_key_value_element_struct;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct gss_key_value_set_struct {
-    pub count: usize,
+    pub count: OM_uint32,
     pub elements: *mut gss_key_value_element_desc,
 }
 pub type gss_key_value_set_desc = gss_key_value_set_struct;

--- a/rust/src/security/gssapi_bindings.rs
+++ b/rust/src/security/gssapi_bindings.rs
@@ -76,6 +76,22 @@ pub type gss_int32 = i32;
 pub type OM_uint32 = gss_uint32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct gss_key_value_element_struct {
+    pub key: *const ::std::os::raw::c_char,
+    pub value: *const ::std::os::raw::c_char,
+}
+pub type gss_key_value_element_desc = gss_key_value_element_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct gss_key_value_set_struct {
+    pub count: usize,
+    pub elements: *mut gss_key_value_element_desc,
+}
+pub type gss_key_value_set_desc = gss_key_value_set_struct;
+pub type gss_key_value_set_t = *mut gss_key_value_set_struct;
+pub type gss_const_key_value_set_t = *const gss_key_value_set_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct gss_OID_desc_struct {
     pub length: OM_uint32,
     pub elements: *mut ::std::os::raw::c_void,
@@ -213,6 +229,20 @@ pub struct GSSAPI {
             arg6: *mut gss_cred_id_t,
             arg7: *mut gss_OID_set,
             arg8: *mut OM_uint32,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_acquire_cred_from: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: OM_uint32,
+            arg4: gss_OID_set,
+            arg5: gss_cred_usage_t,
+            arg6: gss_const_key_value_set_t,
+            arg7: *mut gss_cred_id_t,
+            arg8: *mut gss_OID_set,
+            arg9: *mut OM_uint32,
         ) -> OM_uint32,
         ::libloading::Error,
     >,
@@ -683,6 +713,9 @@ impl GSSAPI {
             .get::<*mut gss_OID>(b"GSS_C_NT_EXPORT_NAME\0")
             .map(|sym| *sym);
         let gss_acquire_cred = __library.get(b"gss_acquire_cred\0").map(|sym| *sym);
+        let gss_acquire_cred_from = __library
+            .get(b"gss_acquire_cred_from\0")
+            .map(|sym| *sym);
         let gss_release_cred = __library.get(b"gss_release_cred\0").map(|sym| *sym);
         let gss_init_sec_context = __library.get(b"gss_init_sec_context\0").map(|sym| *sym);
         let gss_accept_sec_context = __library.get(b"gss_accept_sec_context\0").map(|sym| *sym);
@@ -777,6 +810,7 @@ impl GSSAPI {
             GSS_C_NT_ANONYMOUS,
             GSS_C_NT_EXPORT_NAME,
             gss_acquire_cred,
+            gss_acquire_cred_from,
             gss_release_cred,
             gss_init_sec_context,
             gss_accept_sec_context,
@@ -893,6 +927,25 @@ impl GSSAPI {
             .as_ref()
             .expect("Expected function, got error."))(
             arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8,
+        )
+    }
+    pub unsafe fn gss_acquire_cred_from(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: OM_uint32,
+        arg4: gss_OID_set,
+        arg5: gss_cred_usage_t,
+        arg6: gss_const_key_value_set_t,
+        arg7: *mut gss_cred_id_t,
+        arg8: *mut gss_OID_set,
+        arg9: *mut OM_uint32,
+    ) -> OM_uint32 {
+        (self
+            .gss_acquire_cred_from
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
         )
     }
     pub unsafe fn gss_release_cred(

--- a/rust/src/security/mod.rs
+++ b/rust/src/security/mod.rs
@@ -16,12 +16,63 @@ pub enum KerberosCredentials {
     /// `cache` uses the Kerberos credential-cache syntax, for example
     /// `FILE:/run/krb5/client.ccache` or `DIR:/run/krb5/ccaches`.
     CredentialCache { principal: String, cache: String },
+    /// Acquire credentials for `principal` directly from a keytab.
+    ///
+    /// A private in-memory credential cache is allocated for the client so
+    /// that credential acquisition and renewal do not use process-global state.
+    Keytab { principal: String, keytab: String },
+}
+
+#[derive(Clone)]
+pub(crate) enum ResolvedKerberosCredentials {
+    CredentialCache {
+        principal: String,
+        cache: String,
+    },
+    Keytab {
+        principal: String,
+        keytab: String,
+        cache: String,
+    },
 }
 
 impl KerberosCredentials {
+    pub(crate) fn resolve(self) -> ResolvedKerberosCredentials {
+        match self {
+            Self::CredentialCache { principal, cache } => {
+                ResolvedKerberosCredentials::CredentialCache { principal, cache }
+            }
+            Self::Keytab { principal, keytab } => ResolvedKerberosCredentials::Keytab {
+                principal,
+                keytab,
+                cache: format!("MEMORY:hdfs-native-{}", uuid::Uuid::new_v4()),
+            },
+        }
+    }
+}
+
+impl ResolvedKerberosCredentials {
     pub(crate) fn principal(&self) -> &str {
         match self {
-            Self::CredentialCache { principal, .. } => principal,
+            Self::CredentialCache { principal, .. } | Self::Keytab { principal, .. } => principal,
+        }
+    }
+}
+
+impl std::fmt::Debug for ResolvedKerberosCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CredentialCache { principal, .. } => f
+                .debug_struct("CredentialCache")
+                .field("principal", principal)
+                .field("cache", &"[REDACTED]")
+                .finish(),
+            Self::Keytab { principal, .. } => f
+                .debug_struct("Keytab")
+                .field("principal", principal)
+                .field("keytab", &"[REDACTED]")
+                .field("cache", &"[REDACTED]")
+                .finish(),
         }
     }
 }
@@ -33,6 +84,11 @@ impl std::fmt::Debug for KerberosCredentials {
                 .debug_struct("CredentialCache")
                 .field("principal", principal)
                 .field("cache", &"[REDACTED]")
+                .finish(),
+            Self::Keytab { principal, .. } => f
+                .debug_struct("Keytab")
+                .field("principal", principal)
+                .field("keytab", &"[REDACTED]")
                 .finish(),
         }
     }
@@ -53,5 +109,18 @@ mod tests {
         assert!(debug.contains("alice@EXAMPLE.COM"));
         assert!(debug.contains("[REDACTED]"));
         assert!(!debug.contains("/run/secrets/alice.ccache"));
+    }
+
+    #[test]
+    fn kerberos_credentials_debug_redacts_keytab() {
+        let credentials = KerberosCredentials::Keytab {
+            principal: "alice@EXAMPLE.COM".to_string(),
+            keytab: "/run/secrets/alice.keytab".to_string(),
+        };
+
+        let debug = format!("{credentials:?}");
+        assert!(debug.contains("alice@EXAMPLE.COM"));
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("/run/secrets/alice.keytab"));
     }
 }

--- a/rust/src/security/mod.rs
+++ b/rust/src/security/mod.rs
@@ -7,90 +7,58 @@ pub mod user;
 
 /// Kerberos credentials to use for a single HDFS client.
 ///
-/// Explicit credentials avoid relying on process-global state such as
-/// `KRB5CCNAME`, allowing clients with different identities to coexist.
-#[derive(Clone)]
-pub enum KerberosCredentials {
-    /// Acquire credentials for `principal` from the named credential cache.
-    ///
-    /// `cache` uses the Kerberos credential-cache syntax, for example
-    /// `FILE:/run/krb5/client.ccache` or `DIR:/run/krb5/ccaches`.
-    CredentialCache { principal: String, cache: String },
-    /// Acquire credentials for `principal` directly from a keytab.
-    ///
-    /// A private in-memory credential cache is allocated for the client so
-    /// that credential acquisition and renewal do not use process-global state.
-    Keytab { principal: String, keytab: String },
+/// The fields are independent: a keytab and cache may be supplied together so
+/// acquired tickets are written to that cache. If a keytab is supplied without
+/// a cache, the client allocates a private in-memory cache. Supplying only a
+/// principal selects that identity from the process-default credential store.
+#[derive(Clone, Default)]
+pub(crate) struct KerberosCredentials {
+    pub principal: Option<String>,
+    pub keytab: Option<String>,
+    pub cache: Option<String>,
 }
 
 #[derive(Clone)]
-pub(crate) enum ResolvedKerberosCredentials {
-    CredentialCache {
-        principal: String,
-        cache: String,
-    },
-    Keytab {
-        principal: String,
-        keytab: String,
-        cache: String,
-    },
+pub(crate) struct ResolvedKerberosCredentials {
+    pub(crate) principal: Option<String>,
+    pub(crate) keytab: Option<String>,
+    pub(crate) cache: Option<String>,
 }
 
 impl KerberosCredentials {
-    pub(crate) fn resolve(self) -> ResolvedKerberosCredentials {
-        match self {
-            Self::CredentialCache { principal, cache } => {
-                ResolvedKerberosCredentials::CredentialCache { principal, cache }
-            }
-            Self::Keytab { principal, keytab } => ResolvedKerberosCredentials::Keytab {
-                principal,
-                keytab,
-                cache: format!("MEMORY:hdfs-native-{}", uuid::Uuid::new_v4()),
-            },
+    pub(crate) fn resolve(self) -> Option<ResolvedKerberosCredentials> {
+        if self.principal.is_none() && self.keytab.is_none() && self.cache.is_none() {
+            return None;
         }
-    }
-}
-
-impl ResolvedKerberosCredentials {
-    pub(crate) fn principal(&self) -> &str {
-        match self {
-            Self::CredentialCache { principal, .. } | Self::Keytab { principal, .. } => principal,
-        }
-    }
-}
-
-impl std::fmt::Debug for ResolvedKerberosCredentials {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::CredentialCache { principal, .. } => f
-                .debug_struct("CredentialCache")
-                .field("principal", principal)
-                .field("cache", &"[REDACTED]")
-                .finish(),
-            Self::Keytab { principal, .. } => f
-                .debug_struct("Keytab")
-                .field("principal", principal)
-                .field("keytab", &"[REDACTED]")
-                .field("cache", &"[REDACTED]")
-                .finish(),
-        }
+        let cache = match (&self.keytab, self.cache) {
+            (Some(_), None) => Some(format!("MEMORY:hdfs-native-{}", uuid::Uuid::new_v4())),
+            (_, cache) => cache,
+        };
+        Some(ResolvedKerberosCredentials {
+            principal: self.principal,
+            keytab: self.keytab,
+            cache,
+        })
     }
 }
 
 impl std::fmt::Debug for KerberosCredentials {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::CredentialCache { principal, .. } => f
-                .debug_struct("CredentialCache")
-                .field("principal", principal)
-                .field("cache", &"[REDACTED]")
-                .finish(),
-            Self::Keytab { principal, .. } => f
-                .debug_struct("Keytab")
-                .field("principal", principal)
-                .field("keytab", &"[REDACTED]")
-                .finish(),
-        }
+        f.debug_struct("KerberosCredentials")
+            .field("principal", &self.principal)
+            .field("keytab", &self.keytab.as_ref().map(|_| "[REDACTED]"))
+            .field("cache", &self.cache.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for ResolvedKerberosCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedKerberosCredentials")
+            .field("principal", &self.principal)
+            .field("keytab", &self.keytab.as_ref().map(|_| "[REDACTED]"))
+            .field("cache", &self.cache.as_ref().map(|_| "[REDACTED]"))
+            .finish()
     }
 }
 
@@ -99,28 +67,44 @@ mod tests {
     use super::KerberosCredentials;
 
     #[test]
-    fn kerberos_credentials_debug_redacts_cache() {
-        let credentials = KerberosCredentials::CredentialCache {
-            principal: "alice@EXAMPLE.COM".to_string(),
-            cache: "FILE:/run/secrets/alice.ccache".to_string(),
+    fn kerberos_credentials_are_composable_and_redacted() {
+        let credentials = KerberosCredentials {
+            principal: Some("alice@EXAMPLE.COM".to_string()),
+            keytab: Some("/run/secrets/alice.keytab".to_string()),
+            cache: Some("FILE:/run/krb5/alice.ccache".to_string()),
         };
 
         let debug = format!("{credentials:?}");
         assert!(debug.contains("alice@EXAMPLE.COM"));
-        assert!(debug.contains("[REDACTED]"));
-        assert!(!debug.contains("/run/secrets/alice.ccache"));
+        assert!(!debug.contains("/run/secrets/alice.keytab"));
+        assert!(!debug.contains("/run/krb5/alice.ccache"));
+
+        let resolved = credentials.resolve().unwrap();
+        assert_eq!(
+            resolved.keytab.as_deref(),
+            Some("/run/secrets/alice.keytab")
+        );
+        assert_eq!(
+            resolved.cache.as_deref(),
+            Some("FILE:/run/krb5/alice.ccache")
+        );
     }
 
     #[test]
-    fn kerberos_credentials_debug_redacts_keytab() {
-        let credentials = KerberosCredentials::Keytab {
-            principal: "alice@EXAMPLE.COM".to_string(),
-            keytab: "/run/secrets/alice.keytab".to_string(),
-        };
+    fn keytab_without_cache_gets_private_memory_cache() {
+        let resolved = KerberosCredentials {
+            principal: None,
+            keytab: Some("/run/secrets/alice.keytab".to_string()),
+            cache: None,
+        }
+        .resolve()
+        .unwrap();
 
-        let debug = format!("{credentials:?}");
-        assert!(debug.contains("alice@EXAMPLE.COM"));
-        assert!(debug.contains("[REDACTED]"));
-        assert!(!debug.contains("/run/secrets/alice.keytab"));
+        assert!(resolved.cache.unwrap().starts_with("MEMORY:hdfs-native-"));
+    }
+
+    #[test]
+    fn empty_credentials_use_default_path() {
+        assert!(KerberosCredentials::default().resolve().is_none());
     }
 }

--- a/rust/src/security/mod.rs
+++ b/rust/src/security/mod.rs
@@ -4,3 +4,54 @@ pub(crate) mod gssapi;
 pub(crate) mod kms;
 pub mod sasl;
 pub mod user;
+
+/// Kerberos credentials to use for a single HDFS client.
+///
+/// Explicit credentials avoid relying on process-global state such as
+/// `KRB5CCNAME`, allowing clients with different identities to coexist.
+#[derive(Clone)]
+pub enum KerberosCredentials {
+    /// Acquire credentials for `principal` from the named credential cache.
+    ///
+    /// `cache` uses the Kerberos credential-cache syntax, for example
+    /// `FILE:/run/krb5/client.ccache` or `DIR:/run/krb5/ccaches`.
+    CredentialCache { principal: String, cache: String },
+}
+
+impl KerberosCredentials {
+    pub(crate) fn principal(&self) -> &str {
+        match self {
+            Self::CredentialCache { principal, .. } => principal,
+        }
+    }
+}
+
+impl std::fmt::Debug for KerberosCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CredentialCache { principal, .. } => f
+                .debug_struct("CredentialCache")
+                .field("principal", principal)
+                .field("cache", &"[REDACTED]")
+                .finish(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KerberosCredentials;
+
+    #[test]
+    fn kerberos_credentials_debug_redacts_cache() {
+        let credentials = KerberosCredentials::CredentialCache {
+            principal: "alice@EXAMPLE.COM".to_string(),
+            cache: "FILE:/run/secrets/alice.ccache".to_string(),
+        };
+
+        let debug = format!("{credentials:?}");
+        assert!(debug.contains("alice@EXAMPLE.COM"));
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("/run/secrets/alice.ccache"));
+    }
+}

--- a/rust/src/security/sasl.rs
+++ b/rust/src/security/sasl.rs
@@ -73,7 +73,7 @@ pub(crate) async fn negotiate_sasl_session(
     service: &str,
     config: &Configuration,
     effective_user: Option<String>,
-    kerberos_credentials: Option<&crate::KerberosCredentials>,
+    kerberos_credentials: Option<&crate::security::ResolvedKerberosCredentials>,
 ) -> Result<(UserInfo, SaslReader, SaslWriter)> {
     let (reader, writer) = stream.into_split();
     let mut reader = SaslReader::new(reader);
@@ -187,7 +187,7 @@ fn select_method(
     auths: &[SaslAuth],
     service: &str,
     effective_user: Option<String>,
-    kerberos_credentials: Option<&crate::KerberosCredentials>,
+    kerberos_credentials: Option<&crate::security::ResolvedKerberosCredentials>,
 ) -> Result<(SaslAuth, Option<Box<dyn SaslSession>>)> {
     let user = User::get();
     for auth in auths.iter() {

--- a/rust/src/security/sasl.rs
+++ b/rust/src/security/sasl.rs
@@ -73,6 +73,7 @@ pub(crate) async fn negotiate_sasl_session(
     service: &str,
     config: &Configuration,
     effective_user: Option<String>,
+    kerberos_credentials: Option<&crate::KerberosCredentials>,
 ) -> Result<(UserInfo, SaslReader, SaslWriter)> {
     let (reader, writer) = stream.into_split();
     let mut reader = SaslReader::new(reader);
@@ -97,8 +98,12 @@ pub(crate) async fn negotiate_sasl_session(
         debug!("Handling SASL message: {:?}", message);
         match SaslState::try_from(message.state).unwrap() {
             SaslState::Negotiate => {
-                let (mut selected_auth, selected_session) =
-                    select_method(&message.auths, service, effective_user.clone())?;
+                let (mut selected_auth, selected_session) = select_method(
+                    &message.auths,
+                    service,
+                    effective_user.clone(),
+                    kerberos_credentials,
+                )?;
                 session = selected_session;
 
                 let token = if let Some(session) = session.as_mut() {
@@ -182,6 +187,7 @@ fn select_method(
     auths: &[SaslAuth],
     service: &str,
     effective_user: Option<String>,
+    kerberos_credentials: Option<&crate::KerberosCredentials>,
 ) -> Result<(SaslAuth, Option<Box<dyn SaslSession>>)> {
     let user = User::get();
     for auth in auths.iter() {
@@ -193,11 +199,15 @@ fn select_method(
                 return Ok((auth.clone(), None));
             }
             (Some(AuthMethod::Kerberos), _) => {
-                let session =
-                    GssapiSession::new(auth.protocol(), auth.server_id(), effective_user)?;
+                let session = GssapiSession::new(
+                    auth.protocol(),
+                    auth.server_id(),
+                    effective_user,
+                    kerberos_credentials,
+                )?;
                 return Ok((auth.clone(), Some(Box::new(session))));
             }
-            (Some(AuthMethod::Token), Some(token)) => {
+            (Some(AuthMethod::Token), Some(token)) if kerberos_credentials.is_none() => {
                 let session = DigestSaslSession::from_token(
                     auth.protocol().to_string(),
                     auth.server_id().to_string(),

--- a/rust/src/sync.rs
+++ b/rust/src/sync.rs
@@ -63,8 +63,15 @@ impl ClientBuilder {
     }
 
     /// Set Kerberos credentials scoped to this client instance.
-    pub fn with_kerberos_credentials(mut self, credentials: crate::KerberosCredentials) -> Self {
-        self.inner = self.inner.with_kerberos_credentials(credentials);
+    pub fn with_kerberos_credentials(
+        mut self,
+        principal: Option<String>,
+        keytab: Option<String>,
+        cache: Option<String>,
+    ) -> Self {
+        self.inner = self
+            .inner
+            .with_kerberos_credentials(principal, keytab, cache);
         self
     }
 

--- a/rust/src/sync.rs
+++ b/rust/src/sync.rs
@@ -62,6 +62,12 @@ impl ClientBuilder {
         self
     }
 
+    /// Set Kerberos credentials scoped to this client instance.
+    pub fn with_kerberos_credentials(mut self, credentials: crate::KerberosCredentials) -> Self {
+        self.inner = self.inner.with_kerberos_credentials(credentials);
+        self
+    }
+
     /// Create the synchronous [`Client`] from the provided settings.
     pub fn build(self) -> Result<Client> {
         let rt = Arc::new(Runtime::new()?);

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -1,7 +1,30 @@
 #![allow(dead_code)]
 use bytes::Buf;
+use std::ffi::OsString;
 
 pub const TEST_FILE_INTS: usize = 4 * 1024 * 1024;
+
+pub struct EnvVarGuard {
+    name: &'static str,
+    original: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    pub fn set(name: &'static str, value: &str) -> Self {
+        let original = std::env::var_os(name);
+        unsafe { std::env::set_var(name, value) };
+        Self { name, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.original.take() {
+            Some(value) => unsafe { std::env::set_var(self.name, value) },
+            None => unsafe { std::env::remove_var(self.name) },
+        }
+    }
+}
 
 pub fn assert_bufs_equal(buf1: &impl Buf, buf2: &impl Buf, message: Option<String>) {
     assert_eq!(buf1.chunk().len(), buf2.chunk().len());

--- a/rust/tests/test_failover.rs
+++ b/rust/tests/test_failover.rs
@@ -9,7 +9,7 @@ mod test {
     use std::time::Duration;
 
     use hdfs_native::{
-        Client, ClientBuilder, KerberosCredentials, Result,
+        Client, ClientBuilder, Result,
         minidfs::{DfsFeatures, MiniDfs},
         test::NAMENODE_STANDBY_FAULT_INJECTOR,
     };
@@ -49,10 +49,11 @@ mod test {
         let _dfs = MiniDfs::with_features(&HashSet::from([DfsFeatures::Security, DfsFeatures::HA]));
         let _cache_guard = EnvVarGuard::set("KRB5CCNAME", "FILE:target/test/nonexistent-cache");
         let client = ClientBuilder::new()
-            .with_kerberos_credentials(KerberosCredentials::Keytab {
-                principal: "hdfs/localhost".to_string(),
-                keytab: "target/test/hdfs.keytab".to_string(),
-            })
+            .with_kerberos_credentials(
+                Some("hdfs/localhost".to_string()),
+                Some("target/test/hdfs.keytab".to_string()),
+                None,
+            )
             .build()?;
 
         client

--- a/rust/tests/test_failover.rs
+++ b/rust/tests/test_failover.rs
@@ -1,11 +1,15 @@
 #[cfg(feature = "integration-test")]
+mod common;
+
+#[cfg(feature = "integration-test")]
 mod test {
+    use crate::common::EnvVarGuard;
     use std::collections::HashSet;
     use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     use hdfs_native::{
-        Client, Result,
+        Client, ClientBuilder, KerberosCredentials, Result,
         minidfs::{DfsFeatures, MiniDfs},
         test::NAMENODE_STANDBY_FAULT_INJECTOR,
     };
@@ -34,6 +38,41 @@ mod test {
         write_during_failover.await.unwrap()?;
         assert!(client.get_file_info("/during-failover").await.is_ok());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_explicit_keytab_survives_ha_reconnect() -> Result<()> {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let _dfs = MiniDfs::with_features(&HashSet::from([DfsFeatures::Security, DfsFeatures::HA]));
+        let _cache_guard = EnvVarGuard::set("KRB5CCNAME", "FILE:target/test/nonexistent-cache");
+        let client = ClientBuilder::new()
+            .with_kerberos_credentials(KerberosCredentials::Keytab {
+                principal: "hdfs/localhost".to_string(),
+                keytab: "target/test/hdfs.keytab".to_string(),
+            })
+            .build()?;
+
+        client
+            .mkdirs("/keytab-before-failover", 0o755, true)
+            .await?;
+        NAMENODE_STANDBY_FAULT_INJECTOR.store(true, Ordering::SeqCst);
+        let operation = tokio::spawn({
+            let client = client.clone();
+            async move { client.mkdirs("/keytab-during-failover", 0o755, true).await }
+        });
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        NAMENODE_STANDBY_FAULT_INJECTOR.store(false, Ordering::SeqCst);
+
+        operation.await.unwrap()?;
+        assert!(
+            client
+                .get_file_info("/keytab-during-failover")
+                .await
+                .is_ok()
+        );
         Ok(())
     }
 }

--- a/rust/tests/test_integration.rs
+++ b/rust/tests/test_integration.rs
@@ -6,7 +6,7 @@ mod test {
     use crate::common::{EnvVarGuard, TEST_FILE_INTS, assert_bufs_equal};
     use bytes::{BufMut, Bytes, BytesMut};
     use hdfs_native::{
-        Client, KerberosCredentials, Result, WriteOptions,
+        Client, Result, WriteOptions,
         acl::AclEntry,
         client::{ClientBuilder, FileStatus},
         minidfs::{DfsFeatures, MiniDfs},
@@ -41,10 +41,11 @@ mod test {
 
         let client = ClientBuilder::new()
             .with_url(&dfs.url)
-            .with_kerberos_credentials(KerberosCredentials::Keytab {
-                principal: "hdfs/localhost".to_string(),
-                keytab: "target/test/hdfs.keytab".to_string(),
-            })
+            .with_kerberos_credentials(
+                Some("hdfs/localhost".to_string()),
+                Some("target/test/hdfs.keytab".to_string()),
+                None,
+            )
             .build()
             .unwrap();
         assert_explicit_kerberos_io(&client, "/explicit-keytab").await;
@@ -58,13 +59,32 @@ mod test {
 
         let client = ClientBuilder::new()
             .with_url(&dfs.url)
-            .with_kerberos_credentials(KerberosCredentials::CredentialCache {
-                principal: "hdfs/localhost".to_string(),
-                cache: "FILE:target/test/krbcache".to_string(),
-            })
+            .with_kerberos_credentials(
+                Some("hdfs/localhost".to_string()),
+                None,
+                Some("FILE:target/test/krbcache".to_string()),
+            )
             .build()
             .unwrap();
         assert_explicit_kerberos_io(&client, "/explicit-cache").await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_security_kerberos_keytab_populates_explicit_cache() {
+        let dfs = MiniDfs::with_features(&HashSet::from([DfsFeatures::Security]));
+        let _cache_guard = EnvVarGuard::set("KRB5CCNAME", "FILE:target/test/nonexistent-cache");
+
+        let client = ClientBuilder::new()
+            .with_url(&dfs.url)
+            .with_kerberos_credentials(
+                Some("hdfs/localhost".to_string()),
+                Some("target/test/hdfs.keytab".to_string()),
+                Some("FILE:target/test/explicit-keytab-cache".to_string()),
+            )
+            .build()
+            .unwrap();
+        assert_explicit_kerberos_io(&client, "/explicit-keytab-cache").await;
     }
 
     async fn assert_explicit_kerberos_io(client: &Client, path: &str) {

--- a/rust/tests/test_integration.rs
+++ b/rust/tests/test_integration.rs
@@ -3,10 +3,10 @@ mod common;
 
 #[cfg(feature = "integration-test")]
 mod test {
-    use crate::common::{TEST_FILE_INTS, assert_bufs_equal};
-    use bytes::{BufMut, BytesMut};
+    use crate::common::{EnvVarGuard, TEST_FILE_INTS, assert_bufs_equal};
+    use bytes::{BufMut, Bytes, BytesMut};
     use hdfs_native::{
-        Client, Result, WriteOptions,
+        Client, KerberosCredentials, Result, WriteOptions,
         acl::AclEntry,
         client::{ClientBuilder, FileStatus},
         minidfs::{DfsFeatures, MiniDfs},
@@ -31,6 +31,57 @@ mod test {
         test_with_features(&HashSet::from([DfsFeatures::Security]))
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_security_kerberos_explicit_keytab_without_default_cache() {
+        let dfs = MiniDfs::with_features(&HashSet::from([DfsFeatures::Security]));
+        let _cache_guard = EnvVarGuard::set("KRB5CCNAME", "FILE:target/test/nonexistent-cache");
+
+        let client = ClientBuilder::new()
+            .with_url(&dfs.url)
+            .with_kerberos_credentials(KerberosCredentials::Keytab {
+                principal: "hdfs/localhost".to_string(),
+                keytab: "target/test/hdfs.keytab".to_string(),
+            })
+            .build()
+            .unwrap();
+        assert_explicit_kerberos_io(&client, "/explicit-keytab").await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_security_kerberos_explicit_cache_without_default_cache() {
+        let dfs = MiniDfs::with_features(&HashSet::from([DfsFeatures::Security]));
+        let _cache_guard = EnvVarGuard::set("KRB5CCNAME", "FILE:target/test/nonexistent-cache");
+
+        let client = ClientBuilder::new()
+            .with_url(&dfs.url)
+            .with_kerberos_credentials(KerberosCredentials::CredentialCache {
+                principal: "hdfs/localhost".to_string(),
+                cache: "FILE:target/test/krbcache".to_string(),
+            })
+            .build()
+            .unwrap();
+        assert_explicit_kerberos_io(&client, "/explicit-cache").await;
+    }
+
+    async fn assert_explicit_kerberos_io(client: &Client, path: &str) {
+        let payload = b"credentials are scoped to this client";
+        let mut writer = client
+            .create(path, WriteOptions::default().overwrite(true))
+            .await
+            .unwrap();
+        writer
+            .write_bytes(Bytes::from_static(payload))
+            .await
+            .unwrap();
+        writer.close().await.unwrap();
+        let mut reader = client.read(path).await.unwrap();
+        let actual = reader.read_bytes(payload.len()).await.unwrap();
+        assert_eq!(actual.as_ref(), payload);
+        assert!(client.delete(path, false).await.unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #319.

## Use case

A long-running process or a Kubernetes Job may need more than one HDFS client, with each client using a different Kerberos principal, keytab, or credential cache. Process-global `KRB5CCNAME` cannot represent those clients safely, and changing it at runtime introduces races when connections are established again after a disconnect or NameNode failover.

Explicit credentials are optional. Applications that do not configure them keep the existing process-default GSSAPI behavior, so workloads that do not use Kerberos need no Kerberos-specific setup.

## Summary

- add public `CredentialCache` and `Keytab` variants and `ClientBuilder::with_kerberos_credentials` for async and sync clients
- acquire initiator credentials with MIT Kerberos `gss_acquire_cred_from` and pass the resulting credential handle to `gss_init_sec_context`
- for `Keytab`, combine `client_keytab` with a unique private `MEMORY:` ccache created once per `Client`; this avoids the process-default cache while allowing MIT GSSAPI to acquire and refresh tickets
- carry the resolved client-scoped configuration through reconnects, NameNode HA failover, and viewfs mounts
- preserve process-default GSSAPI behavior when explicit credentials are not configured
- redact keytab and credential-cache locations from `Debug` output and return an actionable error when the runtime GSSAPI library lacks credential-store support
- prefer the explicitly configured Kerberos identity over ambient delegation tokens
- correct the credential-store FFI `count` field to the MIT ABI type `OM_uint32`

The explicit variants depend on the runtime GSSAPI implementation exporting `gss_acquire_cred_from`. The unchanged default path does not have that requirement.

## Tests

Added Linux MiniDFS integration coverage for:

- an explicit credential cache while the process-default `KRB5CCNAME` points to a nonexistent cache
- an explicit keytab under the same condition, including create/write/read/delete
- an explicit keytab across an HA reconnect/failover

Local verification:

- `cargo test -p hdfs-native`: 41 unit tests and 11 doctests passed
- integration targets containing the new tests compile with `--features integration-test`
- `cargo fmt --all -- --check` and `git diff --check` passed

Real Linux HDFS verification was also performed against Hadoop 3.5.0 on Ubuntu 24.04 with MIT Kerberos 1.20.1. With ambient `KRB5CCNAME` removed, both the explicit cache path and the explicit keytab path authenticated successfully and completed NameNode RPC plus DataNode create/write/read/delete operations. The keytab remained on the HDFS host.

The full upstream integration workflow is waiting for a maintainer to approve GitHub Actions for the fork PR.
