### PR TITLE
Fix CRC32 checksum verification on reads

### DIFF
--- a/rust/minidfs/src/main/java/main/Main.java
+++ b/rust/minidfs/src/main/java/main/Main.java
@@ -54,6 +54,9 @@ public class Main {
         if (flags.contains("trash")) {
             conf.set(FS_TRASH_INTERVAL_KEY, "60");
         }
+        if (flags.contains("crc32")) {
+            conf.set(DFS_CHECKSUM_TYPE_KEY, "CRC32");
+        }
 
         if (flags.contains("security")) {
             kdc = new MiniKdc(MiniKdc.createConf(), new File("target/test/kdc"));
@@ -173,6 +176,15 @@ public class Main {
                 fs.setErasureCodingPolicy(new Path("/ec-3-2"), "RS-3-2-1024k");
                 fs.setErasureCodingPolicy(new Path("/ec-6-3"), "RS-6-3-1024k");
                 fs.setErasureCodingPolicy(new Path("/ec-10-4"), "RS-10-4-1024k");
+            }
+
+            if (flags.contains("crc32")) {
+                DistributedFileSystem fs = dfs.getFileSystem(activeNamenode);
+                try (FSDataOutputStream out = fs.create(new Path("/testfile-crc32"))) {
+                    for (int i = 0; i < 1024; i++) {
+                        out.writeInt(i);
+                    }
+                }
             }
 
             if (flags.contains("kms")) {

--- a/rust/src/hdfs/connection.rs
+++ b/rust/src/hdfs/connection.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicI32, Ordering};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use chrono::{TimeDelta, prelude::*};
-use crc::{CRC_32_CKSUM, CRC_32_ISCSI, Crc, Table};
+use crc::{CRC_32_ISCSI, CRC_32_ISO_HDLC, Crc, Table};
 use log::{debug, warn};
 use once_cell::sync::Lazy;
 use prost::Message;
@@ -34,7 +34,7 @@ const DATA_TRANSFER_VERSION: u16 = 28;
 const MAX_PACKET_HEADER_SIZE: usize = 33;
 const DATANODE_CACHE_EXPIRY: TimeDelta = TimeDelta::seconds(3);
 
-const CRC32: Crc<u32, Table<16>> = Crc::<u32, Table<16>>::new(&CRC_32_CKSUM);
+const CRC32: Crc<u32, Table<16>> = Crc::<u32, Table<16>>::new(&CRC_32_ISO_HDLC);
 const CRC32C: Crc<u32, Table<16>> = Crc::<u32, Table<16>>::new(&CRC_32_ISCSI);
 
 pub(crate) static DATANODE_CACHE: Lazy<DatanodeConnectionCache> =
@@ -820,7 +820,9 @@ mod test {
         security::user::UserInfo,
     };
 
-    use super::{AlignmentContext, RpcConnection, datanode_url};
+    use super::{AlignmentContext, CRC32, ReadPacket, RpcConnection, datanode_url};
+    use crate::HdfsError;
+    use bytes::{BufMut, Bytes, BytesMut};
 
     #[test]
     fn test_max_packet_header_size() {
@@ -932,5 +934,72 @@ mod test {
         let user_info = context.user_info.unwrap();
         assert_eq!(user_info.real_user.as_deref(), Some("real-user"));
         assert_eq!(user_info.effective_user.as_deref(), Some("alice"));
+    }
+
+    fn read_packet(data: &'static [u8], checksums: &[u32]) -> ReadPacket {
+        let mut checksum_bytes = BytesMut::new();
+        for checksum in checksums {
+            checksum_bytes.put_u32(*checksum);
+        }
+        ReadPacket::new(
+            hdfs::PacketHeaderProto::default(),
+            checksum_bytes.freeze(),
+            Bytes::from_static(data),
+        )
+    }
+
+    fn checksum_info(
+        checksum_type: hdfs::ChecksumTypeProto,
+        bytes_per_checksum: u32,
+    ) -> Option<hdfs::ReadOpChecksumInfoProto> {
+        Some(hdfs::ReadOpChecksumInfoProto {
+            checksum: hdfs::ChecksumProto {
+                r#type: checksum_type as i32,
+                bytes_per_checksum,
+            },
+            chunk_offset: 0,
+        })
+    }
+
+    #[test]
+    fn test_crc32_verification() {
+        // 0xCBF43926 is the java.util.zip.CRC32 value Hadoop stores for "123456789"
+        let info = checksum_info(hdfs::ChecksumTypeProto::ChecksumCrc32, 512);
+        let data = read_packet(b"123456789", &[0xCBF43926])
+            .get_data(&info)
+            .unwrap();
+        assert_eq!(data, Bytes::from_static(b"123456789"));
+    }
+
+    #[test]
+    fn test_crc32c_verification() {
+        let info = checksum_info(hdfs::ChecksumTypeProto::ChecksumCrc32c, 512);
+        let data = read_packet(b"123456789", &[0xE3069283])
+            .get_data(&info)
+            .unwrap();
+        assert_eq!(data, Bytes::from_static(b"123456789"));
+    }
+
+    #[test]
+    fn test_crc32_multiple_chunks() {
+        let info = checksum_info(hdfs::ChecksumTypeProto::ChecksumCrc32, 4);
+        let checksums = [
+            CRC32.checksum(b"1234"),
+            CRC32.checksum(b"5678"),
+            CRC32.checksum(b"9"),
+        ];
+        let data = read_packet(b"123456789", &checksums)
+            .get_data(&info)
+            .unwrap();
+        assert_eq!(data, Bytes::from_static(b"123456789"));
+    }
+
+    #[test]
+    fn test_checksum_mismatch() {
+        let info = checksum_info(hdfs::ChecksumTypeProto::ChecksumCrc32c, 512);
+        let err = read_packet(b"123456789", &[0xE3069284])
+            .get_data(&info)
+            .unwrap_err();
+        assert!(matches!(err, HdfsError::ChecksumError));
     }
 }

--- a/rust/src/minidfs.rs
+++ b/rust/src/minidfs.rs
@@ -21,6 +21,7 @@ pub enum DfsFeatures {
     RBF,
     Trash,
     Kms,
+    Crc32,
 }
 
 impl DfsFeatures {
@@ -38,6 +39,7 @@ impl DfsFeatures {
             DfsFeatures::RBF => "rbf",
             DfsFeatures::Trash => "trash",
             DfsFeatures::Kms => "kms",
+            DfsFeatures::Crc32 => "crc32",
         }
     }
 
@@ -50,6 +52,7 @@ impl DfsFeatures {
             "token" => Some(DfsFeatures::Token),
             "trash" => Some(DfsFeatures::Trash),
             "kms" => Some(DfsFeatures::Kms),
+            "crc32" => Some(DfsFeatures::Crc32),
             _ => None,
         }
     }

--- a/rust/tests/test_read.rs
+++ b/rust/tests/test_read.rs
@@ -45,6 +45,26 @@ mod test {
         .unwrap();
     }
 
+    #[tokio::test]
+    #[serial]
+    async fn test_read_crc32() -> Result<()> {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let _dfs = MiniDfs::with_features(&HashSet::from([DfsFeatures::Crc32]));
+        let client = Client::default();
+
+        let reader = client.read("/testfile-crc32").await?;
+        let mut buf = reader.read_range(0, reader.file_length()).await?;
+        for i in 0..1024 {
+            assert_eq!(buf.get_i32(), i);
+        }
+
+        let mut buf = reader.read_range(512 * 4, 4).await?;
+        assert_eq!(buf.get_i32(), 512);
+
+        Ok(())
+    }
+
     async fn test_read(features: &HashSet<DfsFeatures>) -> Result<()> {
         let _ = env_logger::builder().is_test(true).try_init();
 


### PR DESCRIPTION
Changes algorithm used to verify CRC32 read checksums from `CRC-32/CKSUM` (the POSIX `cksum` algo) to `CRC-32/ISO-HDLC` (the zlib algo), matching Hadoop's Java impl and the libhdfs native impl. Previously, reading any file with `dfs.checksum.type=CRC32` failed with a `DataTransferError`.

CRC32C read checksum behavior is unaffected.

Also adds:
- Unit tests for `ReadPacket::get_data` covering CRC32 and CRC32C
- A `crc32` MiniDFS feature that sets `dfs.checksum.type=CRC32` and writes a test file from the Java side, plus an integration test (`test_read_crc32`) that reads it back
