### PR TITLE
Update custom credential handling and add Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,33 @@ Here is a list of currently supported and unsupported but possible future featur
 
 Kerberos (SASL GSSAPI) mechanism is supported through a runtime dynamic link to `libgssapi_krb5`. This must be installed separately, but is likely already installed on your system. If not you can install it by:
 
+Clients can supply explicit Kerberos settings with the following builder
+methods:
+
+- `with_kerberos_principal(principal)` — set the Kerberos principal (required
+  when a keytab or cache is supplied).
+- `with_kerberos_keytab(keytab)` — use a keytab for credential acquisition.
+- `with_kerberos_cache(cache)` — use a credential cache such as
+  `FILE:/run/krb5/client.ccache`.
+
+For example:
+
+```rust,no_run
+use hdfs_native::ClientBuilder;
+
+let client = ClientBuilder::new()
+    .with_url("hdfs://namenode.example.com:9000")
+    .with_kerberos_principal("client@EXAMPLE.COM")
+    .with_kerberos_keytab("/run/secrets/client.keytab")
+    .build()
+    .unwrap();
+```
+
+These methods are available on both the asynchronous and synchronous
+builders. This is native credential-store behavior rather than Hadoop Java's
+Subject-based credential storage. Explicit stores require a GSSAPI
+implementation exporting `gss_acquire_cred_from`.
+
 #### Debian-based systems
 
 ```bash

--- a/python/README.md
+++ b/python/README.md
@@ -15,6 +15,23 @@ client = Client("hdfs://localhost:9000")
 status = client.get_file_info("/file.txt")
 ```
 
+To use explicit Kerberos credentials, pass the principal and optionally a
+keytab and/or credential cache to either `Client` or `AsyncClient`:
+
+```python
+from hdfs_native import Client
+
+client = Client(
+    "hdfs://namenode.example.com:9000",
+    kerberos_principal="client@EXAMPLE.COM",
+    kerberos_keytab="/run/secrets/client.keytab",
+)
+```
+
+`kerberos_principal` is required when `kerberos_keytab` or `kerberos_cache` is
+provided. A keytab without an explicit cache uses a native in-memory cache.
+The same arguments are available on `AsyncClient`.
+
 ## CLI
 There is a built-in CLI `hdfsn` that implements most of the behavior of `hdfs dfs` but with a more bash-like syntax. The easiest way to use the CLI is with UV.
 

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -21,6 +21,29 @@ Simply create a :py:class:`Client <hdfs_native.Client>`.
 
 See :py:class:`Client <hdfs_native.Client>` for supported methods on a client.
 
+Kerberos Credentials
+~~~~~~~~~~~~~~~~~~~~
+
+Pass explicit Kerberos credentials to either client class using keyword
+arguments. A principal is required when a keytab or credential cache is
+provided; a keytab without an explicit cache uses a native in-memory cache.
+
+.. code-block:: python
+
+    from hdfs_native import AsyncClient, Client
+
+    client = Client(
+        "hdfs://namenode.example.com:9000",
+        kerberos_principal="client@EXAMPLE.COM",
+        kerberos_keytab="/run/secrets/client.keytab",
+    )
+
+    cached_client = AsyncClient(
+        "hdfs://namenode.example.com:9000",
+        kerberos_principal="client@EXAMPLE.COM",
+        kerberos_cache="FILE:/run/krb5/client.ccache",
+    )
+
 Common Operations
 ~~~~~~~~~~~~~~~~~
 

--- a/python/hdfs_native/__init__.py
+++ b/python/hdfs_native/__init__.py
@@ -134,8 +134,19 @@ class Client:
         url: Optional[str] = None,
         config: Optional[Dict[str, str]] = None,
         config_dir: Optional[str] = None,
+        *,
+        kerberos_principal: Optional[str] = None,
+        kerberos_keytab: Optional[str] = None,
+        kerberos_cache: Optional[str] = None,
     ):
-        self.inner = RawClient(url, config, config_dir)
+        self.inner = RawClient(
+            url,
+            config,
+            config_dir,
+            kerberos_principal,
+            kerberos_keytab,
+            kerberos_cache,
+        )
 
     def get_file_info(self, path: str) -> FileStatus:
         """Gets the file status for the file at `path`"""
@@ -373,8 +384,19 @@ class AsyncClient:
         url: Optional[str] = None,
         config: Optional[Dict[str, str]] = None,
         config_dir: Optional[str] = None,
+        *,
+        kerberos_principal: Optional[str] = None,
+        kerberos_keytab: Optional[str] = None,
+        kerberos_cache: Optional[str] = None,
     ):
-        self.inner = AsyncRawClient(url, config, config_dir)
+        self.inner = AsyncRawClient(
+            url,
+            config,
+            config_dir,
+            kerberos_principal,
+            kerberos_keytab,
+            kerberos_cache,
+        )
 
     async def get_file_info(self, path: str) -> FileStatus:
         """Gets the file status for the file at `path`"""

--- a/python/hdfs_native/_internal.pyi
+++ b/python/hdfs_native/_internal.pyi
@@ -101,6 +101,9 @@ class RawClient:
         url: Optional[str],
         config: Optional[Dict[str, str]],
         config_dir: Optional[str],
+        kerberos_principal: Optional[str] = None,
+        kerberos_keytab: Optional[str] = None,
+        kerberos_cache: Optional[str] = None,
     ) -> None: ...
     def get_file_info(self, path: str) -> FileStatus: ...
     def list_status(self, path: str, recursive: bool) -> Iterator[FileStatus]: ...
@@ -164,6 +167,9 @@ class AsyncRawClient:
         url: Optional[str],
         config: Optional[Dict[str, str]],
         config_dir: Optional[str],
+        kerberos_principal: Optional[str] = None,
+        kerberos_keytab: Optional[str] = None,
+        kerberos_cache: Optional[str] = None,
     ) -> None: ...
     async def get_file_info(self, path: str) -> FileStatus: ...
     def list_status(self, path: str, recursive: bool) -> AsyncIterator[FileStatus]: ...

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -400,11 +400,14 @@ struct RawClient {
 #[pymethods]
 impl RawClient {
     #[new]
-    #[pyo3(signature = (url, config, config_dir))]
+    #[pyo3(signature = (url, config, config_dir, kerberos_principal=None, kerberos_keytab=None, kerberos_cache=None))]
     pub fn new(
         url: Option<&str>,
         config: Option<HashMap<String, String>>,
         config_dir: Option<&str>,
+        kerberos_principal: Option<&str>,
+        kerberos_keytab: Option<&str>,
+        kerberos_cache: Option<&str>,
     ) -> PyResult<Self> {
         // Initialize logging, ignore errors if this is called multiple times
         let _ = env_logger::try_init();
@@ -419,6 +422,18 @@ impl RawClient {
 
         if let Some(config_dir) = config_dir {
             builder = builder.with_config_dir(config_dir);
+        }
+
+        if let Some(principal) = kerberos_principal {
+            builder = builder.with_kerberos_principal(principal);
+        }
+
+        if let Some(keytab) = kerberos_keytab {
+            builder = builder.with_kerberos_keytab(keytab);
+        }
+
+        if let Some(cache) = kerberos_cache {
+            builder = builder.with_kerberos_cache(cache);
         }
 
         let inner = builder.build().map_err(PythonHdfsError::from)?;
@@ -679,11 +694,14 @@ struct AsyncRawClient {
 #[pymethods]
 impl AsyncRawClient {
     #[new]
-    #[pyo3(signature = (url, config, config_dir))]
+    #[pyo3(signature = (url, config, config_dir, kerberos_principal=None, kerberos_keytab=None, kerberos_cache=None))]
     pub fn new(
         url: Option<&str>,
         config: Option<HashMap<String, String>>,
         config_dir: Option<&str>,
+        kerberos_principal: Option<&str>,
+        kerberos_keytab: Option<&str>,
+        kerberos_cache: Option<&str>,
     ) -> PyResult<Self> {
         // Initialize logging, ignore errors if this is called multiple times
         let _ = env_logger::try_init();
@@ -698,6 +716,18 @@ impl AsyncRawClient {
 
         if let Some(config_dir) = config_dir {
             builder = builder.with_config_dir(config_dir);
+        }
+
+        if let Some(principal) = kerberos_principal {
+            builder = builder.with_kerberos_principal(principal);
+        }
+
+        if let Some(keytab) = kerberos_keytab {
+            builder = builder.with_kerberos_keytab(keytab);
+        }
+
+        if let Some(cache) = kerberos_cache {
+            builder = builder.with_kerberos_cache(cache);
         }
 
         let inner = builder.build().map_err(PythonHdfsError::from)?;

--- a/rust/c_src/gssapi_mit.h
+++ b/rust/c_src/gssapi_mit.h
@@ -1,22 +1,6 @@
 #include <gssapi/gssapi.h>
+#include <gssapi/gssapi_ext.h>
 #include <gssapi/gssapi_krb5.h>
-
-// MIT Kerberos credential-store extension. Declare the small subset used here
-// directly because some platforms do not install gssapi_ext.h.
-typedef struct gss_key_value_element_struct {
-    const char *key;
-    const char *value;
-} gss_key_value_element_desc;
-
-typedef struct gss_key_value_set_struct {
-    OM_uint32 count;
-    gss_key_value_element_desc *elements;
-} gss_key_value_set_desc, *gss_key_value_set_t;
-typedef const gss_key_value_set_desc *gss_const_key_value_set_t;
-
-OM_uint32 gss_acquire_cred_from(
-    OM_uint32 *, gss_name_t, OM_uint32, gss_OID_set, gss_cred_usage_t,
-    gss_const_key_value_set_t, gss_cred_id_t *, gss_OID_set *, OM_uint32 *);
 
 const OM_uint32 _GSS_C_INDEFINITE = GSS_C_INDEFINITE;
 const OM_uint32 _GSS_C_CALLING_ERROR_MASK = GSS_C_CALLING_ERROR_MASK;

--- a/rust/examples/kerberos_keytab_probe.rs
+++ b/rust/examples/kerberos_keytab_probe.rs
@@ -17,7 +17,8 @@ async fn main() {
     let client = ClientBuilder::new()
         .with_url(url)
         .with_config_dir(config_dir)
-        .with_kerberos_credentials(Some(principal), Some(keytab), None)
+        .with_kerberos_principal(principal)
+        .with_kerberos_keytab(keytab)
         .build()
         .expect("build keytab-backed client");
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -223,15 +223,15 @@ impl IORuntime {
 ///
 /// Create a client that acquires credentials directly from a keytab:
 ///
+/// An explicit principal is required. A keytab without a supplied cache uses
+/// a native `MEMORY:` credential cache.
+///
 /// ```rust,no_run
 /// # use hdfs_native::ClientBuilder;
 /// let client = ClientBuilder::new()
 ///     .with_url("hdfs://namenode.example.com:9000")
-///     .with_kerberos_credentials(
-///         Some("client@EXAMPLE.COM".into()),
-///         Some("/run/secrets/client.keytab".into()),
-///         None,
-///     )
+///     .with_kerberos_principal("client@EXAMPLE.COM")
+///     .with_kerberos_keytab("/run/secrets/client.keytab")
 ///     .build()
 ///     .unwrap();
 /// ```
@@ -283,11 +283,8 @@ impl IORuntime {
 /// # use hdfs_native::ClientBuilder;
 /// let client = ClientBuilder::new()
 ///     .with_url("hdfs://namenode.example.com:9000")
-///     .with_kerberos_credentials(
-///         Some("client@EXAMPLE.COM".into()),
-///         None,
-///         Some("FILE:/run/krb5/client.ccache".into()),
-///     )
+///     .with_kerberos_principal("client@EXAMPLE.COM")
+///     .with_kerberos_cache("FILE:/run/krb5/client.ccache")
 ///     .build()
 ///     .unwrap();
 /// ```
@@ -298,7 +295,9 @@ pub struct ClientBuilder {
     config_dir: Option<String>,
     runtime: Option<IORuntime>,
     user: Option<String>,
-    kerberos_credentials: Option<crate::security::KerberosCredentials>,
+    kerberos_principal: Option<String>,
+    kerberos_keytab: Option<String>,
+    kerberos_cache: Option<String>,
 }
 
 impl ClientBuilder {
@@ -346,13 +345,34 @@ impl ClientBuilder {
         self
     }
 
-    /// Set Kerberos credentials scoped to this client instance.
+    /// Set the Kerberos principal used by this client.
+    pub fn with_kerberos_principal(mut self, principal: impl Into<String>) -> Self {
+        self.kerberos_principal = Some(principal.into());
+        self
+    }
+
+    /// Set the Kerberos keytab used by this client.
+    pub fn with_kerberos_keytab(mut self, keytab: impl Into<String>) -> Self {
+        self.kerberos_keytab = Some(keytab.into());
+        self
+    }
+
+    /// Set the Kerberos credential cache used by this client.
+    pub fn with_kerberos_cache(mut self, cache: impl Into<String>) -> Self {
+        self.kerberos_cache = Some(cache.into());
+        self
+    }
+
+    /// Set all Kerberos credential fields at once.
     ///
-    /// When unset, Kerberos authentication continues to use the process-default
-    /// GSSAPI credential for backward compatibility. `keytab` and `cache` are
-    /// independent and may be provided together. A keytab without a cache gets
-    /// a private in-memory cache. Explicit credential stores require a runtime
-    /// GSSAPI implementation that exports
+    /// Prefer the individual `with_kerberos_*` methods when constructing a
+    /// client incrementally. When unset, Kerberos authentication continues to
+    /// use the process-default GSSAPI credential for backward compatibility.
+    /// `keytab` and `cache` are independent and may be provided together, but
+    /// an explicit principal is required whenever either is set. A keytab
+    /// without a cache gets an in-memory cache. The all-`None` form is
+    /// equivalent to leaving this method unset. Explicit credential stores
+    /// require a runtime GSSAPI implementation that exports
     /// `gss_acquire_cred_from` (such as MIT Kerberos).
     pub fn with_kerberos_credentials(
         mut self,
@@ -360,11 +380,9 @@ impl ClientBuilder {
         keytab: Option<String>,
         cache: Option<String>,
     ) -> Self {
-        self.kerberos_credentials = Some(crate::security::KerberosCredentials {
-            principal,
-            keytab,
-            cache,
-        });
+        self.kerberos_principal = principal;
+        self.kerberos_keytab = keytab;
+        self.kerberos_cache = cache;
         self
     }
 
@@ -377,15 +395,14 @@ impl ClientBuilder {
             Client::default_fs(&config)?
         };
 
-        Client::build(
-            &url,
-            config,
-            self.runtime,
-            self.user,
-            self.kerberos_credentials
-                .and_then(crate::security::KerberosCredentials::resolve)
-                .map(Arc::new),
-        )
+        let kerberos_credentials = crate::security::KerberosCredentials::new(
+            self.kerberos_principal,
+            self.kerberos_keytab,
+            self.kerberos_cache,
+        )?
+        .map(crate::security::ClientAuth::new);
+
+        Client::build(&url, config, self.runtime, self.user, kerberos_credentials)
     }
 }
 
@@ -448,7 +465,7 @@ impl Client {
         config: Configuration,
         rt: Option<IORuntime>,
         user: Option<String>,
-        kerberos_credentials: Option<Arc<crate::security::ResolvedKerberosCredentials>>,
+        auth: Option<Arc<crate::security::ClientAuth>>,
     ) -> Result<Self> {
         let resolved_url = if !url.has_host() {
             let default_url = Self::default_fs(&config)?;
@@ -467,8 +484,9 @@ impl Client {
         let rt_holder = RuntimeHolder::new(rt);
 
         let user_info = if config.security_enabled()
-            && let Some(principal) = kerberos_credentials
+            && let Some(principal) = auth
                 .as_deref()
+                .and_then(|auth| auth.credentials())
                 .and_then(|credentials| credentials.principal.as_deref())
         {
             User::get_user_info_from_principal(principal, user.clone())
@@ -494,7 +512,7 @@ impl Client {
                     Arc::clone(&config),
                     rt_holder.get_handle(),
                     user.clone(),
-                    kerberos_credentials.clone(),
+                    auth.clone(),
                 )?;
                 let protocol = Arc::new(NamenodeProtocol::new(proxy, rt_holder.get_handle()));
 
@@ -510,7 +528,7 @@ impl Client {
                 Arc::clone(&config),
                 rt_holder.get_handle(),
                 user.clone(),
-                kerberos_credentials,
+                auth.clone(),
                 home_dir,
             )?,
             _ => {
@@ -521,7 +539,8 @@ impl Client {
         };
 
         #[cfg(feature = "kms")]
-        let kms_client = KmsClient::from_config(config.as_ref(), None, username.to_string())?;
+        let kms_client =
+            KmsClient::from_config(config.as_ref(), None, username.to_string(), auth.clone())?;
 
         Ok(Self {
             mount_table: Arc::new(mount_table),
@@ -537,7 +556,7 @@ impl Client {
         config: Arc<Configuration>,
         handle: Handle,
         effective_user: Option<String>,
-        kerberos_credentials: Option<Arc<crate::security::ResolvedKerberosCredentials>>,
+        auth: Option<Arc<crate::security::ClientAuth>>,
         home_dir: String,
     ) -> Result<MountTable> {
         let mut mounts: Vec<MountLink> = Vec::new();
@@ -560,7 +579,7 @@ impl Client {
                 Arc::clone(&config),
                 handle.clone(),
                 effective_user.clone(),
-                kerberos_credentials.clone(),
+                auth.clone(),
             )?;
             let protocol = Arc::new(NamenodeProtocol::new(proxy, handle.clone()));
 
@@ -1721,16 +1740,24 @@ mod test {
         let client = ClientBuilder::new()
             .with_url("hdfs://127.0.0.1:9000")
             .with_config([("hadoop.security.authentication", "kerberos")])
-            .with_kerberos_credentials(
-                Some("alice@EXAMPLE.COM".to_string()),
-                None,
-                Some("FILE:/run/krb5/alice.ccache".to_string()),
-            )
+            .with_kerberos_principal("alice@EXAMPLE.COM")
+            .with_kerberos_cache("FILE:/run/krb5/alice.ccache")
             .build()
             .unwrap();
 
         let (_, resolved) = client.mount_table.resolve("file");
         assert_eq!(resolved, "/user/alice/file");
+    }
+
+    #[test]
+    fn test_explicit_kerberos_credentials_require_principal() {
+        let error = ClientBuilder::new()
+            .with_url("hdfs://127.0.0.1:9000")
+            .with_kerberos_credentials(None, Some("client.keytab".to_string()), None)
+            .build()
+            .unwrap_err();
+
+        assert!(error.to_string().contains("principal is required"));
     }
 
     #[test]

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -363,29 +363,6 @@ impl ClientBuilder {
         self
     }
 
-    /// Set all Kerberos credential fields at once.
-    ///
-    /// Prefer the individual `with_kerberos_*` methods when constructing a
-    /// client incrementally. When unset, Kerberos authentication continues to
-    /// use the process-default GSSAPI credential for backward compatibility.
-    /// `keytab` and `cache` are independent and may be provided together, but
-    /// an explicit principal is required whenever either is set. A keytab
-    /// without a cache gets an in-memory cache. The all-`None` form is
-    /// equivalent to leaving this method unset. Explicit credential stores
-    /// require a runtime GSSAPI implementation that exports
-    /// `gss_acquire_cred_from` (such as MIT Kerberos).
-    pub fn with_kerberos_credentials(
-        mut self,
-        principal: Option<String>,
-        keytab: Option<String>,
-        cache: Option<String>,
-    ) -> Self {
-        self.kerberos_principal = principal;
-        self.kerberos_keytab = keytab;
-        self.kerberos_cache = cache;
-        self
-    }
-
     /// Create the [Client] instance from the provided settings
     pub fn build(self) -> Result<Client> {
         let config = Configuration::new(self.config_dir, self.config)?;
@@ -1753,7 +1730,7 @@ mod test {
     fn test_explicit_kerberos_credentials_require_principal() {
         let error = ClientBuilder::new()
             .with_url("hdfs://127.0.0.1:9000")
-            .with_kerberos_credentials(None, Some("client.keytab".to_string()), None)
+            .with_kerberos_keytab("client.keytab")
             .build()
             .unwrap_err();
 

--- a/rust/src/hdfs/connection.rs
+++ b/rust/src/hdfs/connection.rs
@@ -139,7 +139,7 @@ impl RpcConnection {
         alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
         nameservice: Option<&str>,
         effective_user: Option<String>,
-        kerberos_credentials: Option<&crate::security::ResolvedKerberosCredentials>,
+        auth: Option<std::sync::Arc<crate::security::ClientAuth>>,
         config: &Configuration,
         handle: &Handle,
     ) -> Result<Self> {
@@ -163,14 +163,8 @@ impl RpcConnection {
         let service = nameservice
             .map(|ns| format!("ha-hdfs:{ns}"))
             .unwrap_or(url.to_string());
-        let (user_info, reader, writer) = negotiate_sasl_session(
-            stream,
-            &service,
-            config,
-            effective_user,
-            kerberos_credentials,
-        )
-        .await?;
+        let (user_info, reader, writer) =
+            negotiate_sasl_session(stream, &service, config, effective_user, auth).await?;
         let (sender, receiver) = mpsc::channel::<Vec<u8>>(1000);
 
         let mut conn = RpcConnection {

--- a/rust/src/hdfs/proxy.rs
+++ b/rust/src/hdfs/proxy.rs
@@ -40,7 +40,7 @@ struct ProxyConnection {
     alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
     nameservice: Option<String>,
     effective_user: Option<String>,
-    kerberos_credentials: Option<Arc<crate::security::ResolvedKerberosCredentials>>,
+    auth: Option<Arc<crate::security::ClientAuth>>,
     config: Arc<Configuration>,
     handle: Handle,
 }
@@ -83,7 +83,7 @@ impl ProxyConnection {
         alignment_context: Option<Arc<Mutex<AlignmentContext>>>,
         nameservice: Option<String>,
         effective_user: Option<String>,
-        kerberos_credentials: Option<Arc<crate::security::ResolvedKerberosCredentials>>,
+        auth: Option<Arc<crate::security::ClientAuth>>,
         config: Arc<Configuration>,
         handle: Handle,
     ) -> Self {
@@ -93,7 +93,7 @@ impl ProxyConnection {
             alignment_context,
             nameservice,
             effective_user,
-            kerberos_credentials,
+            auth,
             config,
             handle,
         }
@@ -117,7 +117,7 @@ impl ProxyConnection {
                                 self.alignment_context.clone(),
                                 self.nameservice.as_deref(),
                                 self.effective_user.clone(),
-                                self.kerberos_credentials.as_deref(),
+                                self.auth.clone(),
                                 &self.config,
                                 &self.handle,
                             )
@@ -177,7 +177,7 @@ impl NameServiceProxy {
         config: Arc<Configuration>,
         handle: Handle,
         effective_user: Option<String>,
-        kerberos_credentials: Option<Arc<crate::security::ResolvedKerberosCredentials>>,
+        auth: Option<Arc<crate::security::ClientAuth>>,
     ) -> Result<Self> {
         let host = nameservice.host_str().ok_or(HdfsError::InvalidArgument(
             "No host for name service".to_string(),
@@ -213,7 +213,7 @@ impl NameServiceProxy {
                 alignment_context,
                 None,
                 effective_user,
-                kerberos_credentials,
+                auth,
                 Arc::clone(&config),
                 handle,
             )]
@@ -228,7 +228,7 @@ impl NameServiceProxy {
                         alignment_context.clone(),
                         Some(host.to_string()),
                         effective_user.clone(),
-                        kerberos_credentials.clone(),
+                        auth.clone(),
                         Arc::clone(&config),
                         handle.clone(),
                     )

--- a/rust/src/security/gssapi.rs
+++ b/rust/src/security/gssapi.rs
@@ -10,6 +10,7 @@ use std::{ptr, slice};
 
 use crate::HdfsError;
 
+use super::ClientAuth;
 use super::sasl::SaslSession;
 use super::user::User;
 
@@ -263,7 +264,7 @@ impl GssCred {
         Ok(Self { cred })
     }
 
-    fn acquire(credentials: &crate::security::ResolvedKerberosCredentials) -> crate::Result<Self> {
+    fn acquire(credentials: &crate::security::KerberosCredentials) -> crate::Result<Self> {
         let mut desired_name = credentials
             .principal
             .as_deref()
@@ -415,11 +416,6 @@ unsafe impl Sync for GssClientCtx {}
 impl GssClientCtx {
     fn with_credential(target: GssName, credential: Option<GssCred>) -> Self {
         Self::with_mech_and_credential(target, GssMech::Krb5, credential)
-    }
-
-    #[cfg(feature = "kms")]
-    fn with_mech(target: GssName, mech: GssMech) -> Self {
-        Self::with_mech_and_credential(target, mech, None)
     }
 
     fn with_mech_and_credential(
@@ -676,12 +672,12 @@ impl GssapiSession {
         service: &str,
         hostname: &str,
         effective_user: Option<String>,
-        kerberos_credentials: Option<&crate::security::ResolvedKerberosCredentials>,
+        auth: Option<std::sync::Arc<ClientAuth>>,
     ) -> crate::Result<Self> {
         let targ_name = format!("{service}@{hostname}");
 
         let target = GssName::with_target(&targ_name)?;
-        let credential = match kerberos_credentials {
+        let credential = match auth.as_deref().and_then(ClientAuth::credentials) {
             Some(credentials) => Some(GssCred::acquire(credentials)?),
             None => None,
         };
@@ -712,10 +708,18 @@ pub(crate) struct SpnegoSession {
 
 #[cfg(feature = "kms")]
 impl SpnegoSession {
-    pub(crate) fn new(service: &str, hostname: &str) -> crate::Result<Self> {
+    pub(crate) fn new(
+        service: &str,
+        hostname: &str,
+        auth: Option<std::sync::Arc<ClientAuth>>,
+    ) -> crate::Result<Self> {
         let target = GssName::with_target(&format!("{service}@{hostname}"))?;
+        let credential = match auth.as_deref().and_then(ClientAuth::credentials) {
+            Some(credentials) => Some(GssCred::acquire(credentials)?),
+            None => None,
+        };
         Ok(Self {
-            ctx: GssClientCtx::with_mech(target, GssMech::Spnego),
+            ctx: GssClientCtx::with_mech_and_credential(target, GssMech::Spnego, credential),
             complete: false,
         })
     }

--- a/rust/src/security/gssapi_bindings.rs
+++ b/rust/src/security/gssapi_bindings.rs
@@ -10,12 +10,9 @@ pub const GSS_C_ANON_FLAG: u32 = 64;
 pub const GSS_C_PROT_READY_FLAG: u32 = 128;
 pub const GSS_C_TRANS_FLAG: u32 = 256;
 pub const GSS_C_DELEG_POLICY_FLAG: u32 = 32768;
-pub const GSS_C_NO_UI_FLAG: u32 = 2147483648;
 pub const GSS_C_BOTH: u32 = 0;
 pub const GSS_C_INITIATE: u32 = 1;
 pub const GSS_C_ACCEPT: u32 = 2;
-pub const GSS_C_OPTION_MASK: u32 = 65535;
-pub const GSS_C_CRED_NO_UI: u32 = 65536;
 pub const GSS_C_GSS_CODE: u32 = 1;
 pub const GSS_C_MECH_CODE: u32 = 2;
 pub const GSS_C_AF_UNSPEC: u32 = 0;
@@ -38,6 +35,7 @@ pub const GSS_C_AF_APPLETALK: u32 = 16;
 pub const GSS_C_AF_BSC: u32 = 17;
 pub const GSS_C_AF_DSS: u32 = 18;
 pub const GSS_C_AF_OSI: u32 = 19;
+pub const GSS_C_AF_NETBIOS: u32 = 20;
 pub const GSS_C_AF_X25: u32 = 21;
 pub const GSS_C_AF_NULLADDR: u32 = 255;
 pub const GSS_C_QOP_DEFAULT: u32 = 0;
@@ -50,23 +48,40 @@ pub const GSS_S_DUPLICATE_TOKEN: u32 = 2;
 pub const GSS_S_OLD_TOKEN: u32 = 4;
 pub const GSS_S_UNSEQ_TOKEN: u32 = 8;
 pub const GSS_S_GAP_TOKEN: u32 = 16;
-pub const GSS_KRB5_UI_ALLOW: u32 = 1;
-pub const GSS_KRB5_UI_DENY: u32 = 2;
-pub const GSS_KRB5_UI_PROBE: u32 = 3;
+pub const GSS_C_PRF_KEY_FULL: u32 = 0;
+pub const GSS_C_PRF_KEY_PARTIAL: u32 = 1;
+pub const GSS_C_DCE_STYLE: u32 = 4096;
+pub const GSS_C_IDENTIFY_FLAG: u32 = 8192;
+pub const GSS_C_EXTENDED_ERROR_FLAG: u32 = 16384;
+pub const GSS_IOV_BUFFER_TYPE_EMPTY: u32 = 0;
+pub const GSS_IOV_BUFFER_TYPE_DATA: u32 = 1;
+pub const GSS_IOV_BUFFER_TYPE_HEADER: u32 = 2;
+pub const GSS_IOV_BUFFER_TYPE_MECH_PARAMS: u32 = 3;
+pub const GSS_IOV_BUFFER_TYPE_TRAILER: u32 = 7;
+pub const GSS_IOV_BUFFER_TYPE_PADDING: u32 = 9;
+pub const GSS_IOV_BUFFER_TYPE_STREAM: u32 = 10;
+pub const GSS_IOV_BUFFER_TYPE_SIGN_ONLY: u32 = 11;
+pub const GSS_IOV_BUFFER_TYPE_MIC_TOKEN: u32 = 12;
+pub const GSS_IOV_BUFFER_FLAG_MASK: u32 = 4294901760;
+pub const GSS_IOV_BUFFER_FLAG_ALLOCATE: u32 = 65536;
+pub const GSS_IOV_BUFFER_FLAG_ALLOCATED: u32 = 131072;
+pub const GSS_C_CHANNEL_BOUND_FLAG: u32 = 2048;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type uid_t = __uid_t;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct gss_name_struct {
     _unused: [u8; 0],
 }
 pub type gss_name_t = *mut gss_name_struct;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct gss_cred_id_struct {
     _unused: [u8; 0],
 }
 pub type gss_cred_id_t = *mut gss_cred_id_struct;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct gss_ctx_id_struct {
     _unused: [u8; 0],
 }
@@ -74,22 +89,6 @@ pub type gss_ctx_id_t = *mut gss_ctx_id_struct;
 pub type gss_uint32 = u32;
 pub type gss_int32 = i32;
 pub type OM_uint32 = gss_uint32;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct gss_key_value_element_struct {
-    pub key: *const ::std::os::raw::c_char,
-    pub value: *const ::std::os::raw::c_char,
-}
-pub type gss_key_value_element_desc = gss_key_value_element_struct;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct gss_key_value_set_struct {
-    pub count: OM_uint32,
-    pub elements: *mut gss_key_value_element_desc,
-}
-pub type gss_key_value_set_desc = gss_key_value_set_struct;
-pub type gss_key_value_set_t = *mut gss_key_value_set_struct;
-pub type gss_const_key_value_set_t = *const gss_key_value_set_struct;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct gss_OID_desc_struct {
@@ -126,16 +125,91 @@ pub struct gss_channel_bindings_struct {
 pub type gss_channel_bindings_t = *mut gss_channel_bindings_struct;
 pub type gss_qop_t = OM_uint32;
 pub type gss_cred_usage_t = ::std::os::raw::c_int;
-pub type krb5_int32 = ::std::os::raw::c_int;
-pub type krb5_enctype = krb5_int32;
-pub type krb5_flags = krb5_int32;
+pub type gss_const_buffer_t = *const gss_buffer_desc;
+pub type gss_const_channel_bindings_t = *const gss_channel_bindings_struct;
+pub type gss_const_ctx_id_t = *const gss_ctx_id_struct;
+pub type gss_const_cred_id_t = *const gss_cred_id_struct;
+pub type gss_const_name_t = *const gss_name_struct;
+pub type gss_const_OID = *const gss_OID_desc;
+pub type gss_const_OID_set = *const gss_OID_set_desc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct gss_buffer_set_desc_struct {
+    pub count: usize,
+    pub elements: *mut gss_buffer_desc,
+}
+pub type gss_buffer_set_desc = gss_buffer_set_desc_struct;
+pub type gss_buffer_set_t = *mut gss_buffer_set_desc_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct gss_iov_buffer_desc_struct {
+    pub type_: OM_uint32,
+    pub buffer: gss_buffer_desc,
+}
+pub type gss_iov_buffer_desc = gss_iov_buffer_desc_struct;
+pub type gss_iov_buffer_t = *mut gss_iov_buffer_desc_struct;
+#[repr(C)]
+#[derive(Debug)]
+pub struct gss_any {
+    _unused: [u8; 0],
+}
+pub type gss_any_t = *mut gss_any;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct gss_key_value_element_struct {
+    pub key: *const ::std::os::raw::c_char,
+    pub value: *const ::std::os::raw::c_char,
+}
+pub type gss_key_value_element_desc = gss_key_value_element_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct gss_key_value_set_struct {
+    pub count: OM_uint32,
+    pub elements: *mut gss_key_value_element_desc,
+}
+pub type gss_key_value_set_desc = gss_key_value_set_struct;
+pub type gss_const_key_value_set_t = *const gss_key_value_set_desc;
+pub type krb5_int32 = i32;
+pub type krb5_enctype = krb5_int32;
+pub type krb5_flags = krb5_int32;
+pub type krb5_error_code = krb5_int32;
+pub type krb5_magic = krb5_error_code;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _krb5_data {
+    pub magic: krb5_magic,
+    pub length: ::std::os::raw::c_uint,
+    pub data: *mut ::std::os::raw::c_char,
+}
+pub type krb5_data = _krb5_data;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct krb5_principal_data {
+    pub magic: krb5_magic,
+    pub realm: krb5_data,
+    pub data: *mut krb5_data,
+    pub length: krb5_int32,
+    pub type_: krb5_int32,
+}
+pub type krb5_principal = *mut krb5_principal_data;
+#[repr(C)]
+#[derive(Debug)]
 pub struct _krb5_ccache {
     _unused: [u8; 0],
 }
 pub type krb5_ccache = *mut _krb5_ccache;
-pub type gss_uint64 = u64;
+#[repr(C)]
+#[derive(Debug)]
+pub struct krb5_rc_st {
+    _unused: [u8; 0],
+}
+pub type krb5_rcache = *mut krb5_rc_st;
+#[repr(C)]
+#[derive(Debug)]
+pub struct _krb5_kt {
+    _unused: [u8; 0],
+}
+pub type krb5_keytab = *mut _krb5_kt;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct gss_krb5_lucid_key {
@@ -166,8 +240,8 @@ pub struct gss_krb5_lucid_context_v1 {
     pub version: OM_uint32,
     pub initiate: OM_uint32,
     pub endtime: OM_uint32,
-    pub send_seq: gss_uint64,
-    pub recv_seq: gss_uint64,
+    pub send_seq: u64,
+    pub recv_seq: u64,
     pub protocol: OM_uint32,
     pub rfc1964_kd: gss_krb5_rfc1964_keydata_t,
     pub cfx_kd: gss_krb5_cfx_keydata_t,
@@ -229,20 +303,6 @@ pub struct GSSAPI {
             arg6: *mut gss_cred_id_t,
             arg7: *mut gss_OID_set,
             arg8: *mut OM_uint32,
-        ) -> OM_uint32,
-        ::libloading::Error,
-    >,
-    pub gss_acquire_cred_from: Result<
-        unsafe extern "C" fn(
-            arg1: *mut OM_uint32,
-            arg2: gss_name_t,
-            arg3: OM_uint32,
-            arg4: gss_OID_set,
-            arg5: gss_cred_usage_t,
-            arg6: gss_const_key_value_set_t,
-            arg7: *mut gss_cred_id_t,
-            arg8: *mut gss_OID_set,
-            arg9: *mut OM_uint32,
         ) -> OM_uint32,
         ::libloading::Error,
     >,
@@ -441,6 +501,15 @@ pub struct GSSAPI {
         ) -> OM_uint32,
         ::libloading::Error,
     >,
+    pub gss_import_name_object: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: *mut ::std::os::raw::c_void,
+            arg3: gss_OID,
+            arg4: *mut gss_name_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
     pub gss_export_name_object: Result<
         unsafe extern "C" fn(
             arg1: *mut OM_uint32,
@@ -615,14 +684,543 @@ pub struct GSSAPI {
         ) -> OM_uint32,
         ::libloading::Error,
     >,
-    pub GSS_KRB5_NT_PRINCIPAL_NAME: Result<*mut *const gss_OID_desc, ::libloading::Error>,
-    pub gss_mech_krb5: Result<*mut *const gss_OID_desc, ::libloading::Error>,
-    pub gss_mech_krb5_old: Result<*mut *const gss_OID_desc, ::libloading::Error>,
-    pub gss_mech_set_krb5: Result<*mut *const gss_OID_set_desc, ::libloading::Error>,
-    pub gss_mech_set_krb5_old: Result<*mut *const gss_OID_set_desc, ::libloading::Error>,
-    pub gss_mech_set_krb5_both: Result<*mut *const gss_OID_set_desc, ::libloading::Error>,
-    pub gss_nt_krb5_name: Result<*mut *const gss_OID_desc, ::libloading::Error>,
-    pub gss_nt_krb5_principal: Result<*mut *const gss_OID_desc, ::libloading::Error>,
+    pub gss_pseudo_random: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_ctx_id_t,
+            arg3: ::std::os::raw::c_int,
+            arg4: gss_buffer_t,
+            arg5: isize,
+            arg6: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_store_cred: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_cred_id_t,
+            arg3: gss_cred_usage_t,
+            arg4: gss_OID,
+            arg5: OM_uint32,
+            arg6: OM_uint32,
+            arg7: *mut gss_OID_set,
+            arg8: *mut gss_cred_usage_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_set_neg_mechs: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_cred_id_t,
+            arg3: gss_OID_set,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_indicate_mechs_by_attrs: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_const_OID_set,
+            arg3: gss_const_OID_set,
+            arg4: gss_const_OID_set,
+            arg5: *mut gss_OID_set,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_inquire_attrs_for_mech: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_const_OID,
+            arg3: *mut gss_OID_set,
+            arg4: *mut gss_OID_set,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_display_mech_attr: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_const_OID,
+            arg3: gss_buffer_t,
+            arg4: gss_buffer_t,
+            arg5: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub GSS_C_MA_MECH_CONCRETE: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_MECH_PSEUDO: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_MECH_COMPOSITE: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_MECH_NEGO: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_MECH_GLUE: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_NOT_MECH: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_DEPRECATED: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_NOT_DFLT_MECH: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_ITOK_FRAMED: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_AUTH_INIT: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_AUTH_TARG: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_AUTH_INIT_INIT: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_AUTH_TARG_INIT: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_AUTH_INIT_ANON: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_AUTH_TARG_ANON: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_DELEG_CRED: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_INTEG_PROT: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_CONF_PROT: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_MIC: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_WRAP: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_PROT_READY: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_REPLAY_DET: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_OOS_DET: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_CBINDINGS: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_PFS: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_COMPRESS: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_MA_CTX_TRANS: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub gss_inquire_saslname_for_mech: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_OID,
+            arg3: gss_buffer_t,
+            arg4: gss_buffer_t,
+            arg5: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_inquire_mech_for_saslname: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_buffer_t,
+            arg3: *mut gss_OID,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_pname_to_uid: Result<
+        unsafe extern "C" fn(
+            minor: *mut OM_uint32,
+            name: gss_name_t,
+            mech_type: gss_OID,
+            uidOut: *mut uid_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_localname: Result<
+        unsafe extern "C" fn(
+            minor: *mut OM_uint32,
+            name: gss_name_t,
+            mech_type: gss_const_OID,
+            localname: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_userok: Result<
+        unsafe extern "C" fn(
+            name: gss_name_t,
+            username: *const ::std::os::raw::c_char,
+        ) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+    pub gss_authorize_localname: Result<
+        unsafe extern "C" fn(
+            minor: *mut OM_uint32,
+            name: gss_name_t,
+            user: gss_name_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_acquire_cred_with_password: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: gss_buffer_t,
+            arg4: OM_uint32,
+            arg5: gss_OID_set,
+            arg6: gss_cred_usage_t,
+            arg7: *mut gss_cred_id_t,
+            arg8: *mut gss_OID_set,
+            arg9: *mut OM_uint32,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_add_cred_with_password: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_cred_id_t,
+            arg3: gss_name_t,
+            arg4: gss_OID,
+            arg5: gss_buffer_t,
+            arg6: gss_cred_usage_t,
+            arg7: OM_uint32,
+            arg8: OM_uint32,
+            arg9: *mut gss_cred_id_t,
+            arg10: *mut gss_OID_set,
+            arg11: *mut OM_uint32,
+            arg12: *mut OM_uint32,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_create_empty_buffer_set: Result<
+        unsafe extern "C" fn(arg1: *mut OM_uint32, arg2: *mut gss_buffer_set_t) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_add_buffer_set_member: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_buffer_t,
+            arg3: *mut gss_buffer_set_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_release_buffer_set: Result<
+        unsafe extern "C" fn(arg1: *mut OM_uint32, arg2: *mut gss_buffer_set_t) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_inquire_sec_context_by_oid: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_ctx_id_t,
+            arg3: gss_OID,
+            arg4: *mut gss_buffer_set_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_inquire_cred_by_oid: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_cred_id_t,
+            arg3: gss_OID,
+            arg4: *mut gss_buffer_set_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_set_sec_context_option: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: *mut gss_ctx_id_t,
+            arg3: gss_OID,
+            arg4: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_export_cred: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_cred_id_t,
+            arg3: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_import_cred: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_buffer_t,
+            arg3: *mut gss_cred_id_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_set_cred_option: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: *mut gss_cred_id_t,
+            arg3: gss_OID,
+            arg4: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_wrap_aead: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_ctx_id_t,
+            arg3: ::std::os::raw::c_int,
+            arg4: gss_qop_t,
+            arg5: gss_buffer_t,
+            arg6: gss_buffer_t,
+            arg7: *mut ::std::os::raw::c_int,
+            arg8: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_unwrap_aead: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_ctx_id_t,
+            arg3: gss_buffer_t,
+            arg4: gss_buffer_t,
+            arg5: gss_buffer_t,
+            arg6: *mut ::std::os::raw::c_int,
+            arg7: *mut gss_qop_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub GSS_C_INQ_SSPI_SESSION_KEY: Result<*mut gss_OID, ::libloading::Error>,
+    pub GSS_C_INQ_NEGOEX_KEY: Result<*mut gss_OID, ::libloading::Error>,
+    pub GSS_C_INQ_NEGOEX_VERIFY_KEY: Result<*mut gss_OID, ::libloading::Error>,
+    pub gss_complete_auth_token: Result<
+        unsafe extern "C" fn(
+            minor_status: *mut OM_uint32,
+            context_handle: gss_ctx_id_t,
+            input_message_buffer: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_wrap_iov: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_ctx_id_t,
+            arg3: ::std::os::raw::c_int,
+            arg4: gss_qop_t,
+            arg5: *mut ::std::os::raw::c_int,
+            arg6: *mut gss_iov_buffer_desc,
+            arg7: ::std::os::raw::c_int,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_unwrap_iov: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_ctx_id_t,
+            arg3: *mut ::std::os::raw::c_int,
+            arg4: *mut gss_qop_t,
+            arg5: *mut gss_iov_buffer_desc,
+            arg6: ::std::os::raw::c_int,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_wrap_iov_length: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_ctx_id_t,
+            arg3: ::std::os::raw::c_int,
+            arg4: gss_qop_t,
+            arg5: *mut ::std::os::raw::c_int,
+            arg6: *mut gss_iov_buffer_desc,
+            arg7: ::std::os::raw::c_int,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_get_mic_iov: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_ctx_id_t,
+            arg3: gss_qop_t,
+            arg4: *mut gss_iov_buffer_desc,
+            arg5: ::std::os::raw::c_int,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_get_mic_iov_length: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_ctx_id_t,
+            arg3: gss_qop_t,
+            arg4: *mut gss_iov_buffer_desc,
+            arg5: ::std::os::raw::c_int,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_verify_mic_iov: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_ctx_id_t,
+            arg3: *mut gss_qop_t,
+            arg4: *mut gss_iov_buffer_desc,
+            arg5: ::std::os::raw::c_int,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_release_iov_buffer: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: *mut gss_iov_buffer_desc,
+            arg3: ::std::os::raw::c_int,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_acquire_cred_impersonate_name: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_cred_id_t,
+            arg3: gss_name_t,
+            arg4: OM_uint32,
+            arg5: gss_OID_set,
+            arg6: gss_cred_usage_t,
+            arg7: *mut gss_cred_id_t,
+            arg8: *mut gss_OID_set,
+            arg9: *mut OM_uint32,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_add_cred_impersonate_name: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_cred_id_t,
+            arg3: gss_cred_id_t,
+            arg4: gss_name_t,
+            arg5: gss_OID,
+            arg6: gss_cred_usage_t,
+            arg7: OM_uint32,
+            arg8: OM_uint32,
+            arg9: *mut gss_cred_id_t,
+            arg10: *mut gss_OID_set,
+            arg11: *mut OM_uint32,
+            arg12: *mut OM_uint32,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub GSS_C_ATTR_LOCAL_LOGIN_USER: Result<*mut gss_buffer_t, ::libloading::Error>,
+    pub GSS_C_NT_COMPOSITE_EXPORT: Result<*mut gss_OID, ::libloading::Error>,
+    pub gss_display_name_ext: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: gss_OID,
+            arg4: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_inquire_name: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: *mut ::std::os::raw::c_int,
+            arg4: *mut gss_OID,
+            arg5: *mut gss_buffer_set_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_get_name_attribute: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: gss_buffer_t,
+            arg4: *mut ::std::os::raw::c_int,
+            arg5: *mut ::std::os::raw::c_int,
+            arg6: gss_buffer_t,
+            arg7: gss_buffer_t,
+            arg8: *mut ::std::os::raw::c_int,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_set_name_attribute: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: ::std::os::raw::c_int,
+            arg4: gss_buffer_t,
+            arg5: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_delete_name_attribute: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_export_name_composite: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_map_name_to_any: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: ::std::os::raw::c_int,
+            arg4: gss_buffer_t,
+            arg5: *mut gss_any_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_release_any_name_mapping: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: gss_buffer_t,
+            arg4: *mut gss_any_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_encapsulate_token: Result<
+        unsafe extern "C" fn(
+            arg1: gss_const_buffer_t,
+            arg2: gss_const_OID,
+            arg3: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_decapsulate_token: Result<
+        unsafe extern "C" fn(
+            arg1: gss_const_buffer_t,
+            arg2: gss_const_OID,
+            arg3: gss_buffer_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_oid_equal: Result<
+        unsafe extern "C" fn(arg1: gss_const_OID, arg2: gss_const_OID) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+    pub gss_acquire_cred_from: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_name_t,
+            arg3: OM_uint32,
+            arg4: gss_OID_set,
+            arg5: gss_cred_usage_t,
+            arg6: gss_const_key_value_set_t,
+            arg7: *mut gss_cred_id_t,
+            arg8: *mut gss_OID_set,
+            arg9: *mut OM_uint32,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_add_cred_from: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_cred_id_t,
+            arg3: gss_name_t,
+            arg4: gss_OID,
+            arg5: gss_cred_usage_t,
+            arg6: OM_uint32,
+            arg7: OM_uint32,
+            arg8: gss_const_key_value_set_t,
+            arg9: *mut gss_cred_id_t,
+            arg10: *mut gss_OID_set,
+            arg11: *mut OM_uint32,
+            arg12: *mut OM_uint32,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_store_cred_into: Result<
+        unsafe extern "C" fn(
+            arg1: *mut OM_uint32,
+            arg2: gss_cred_id_t,
+            arg3: gss_cred_usage_t,
+            arg4: gss_OID,
+            arg5: OM_uint32,
+            arg6: OM_uint32,
+            arg7: gss_const_key_value_set_t,
+            arg8: *mut gss_OID_set,
+            arg9: *mut gss_cred_usage_t,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub GSS_C_MA_NEGOEX_AND_SPNEGO: Result<*mut gss_const_OID, ::libloading::Error>,
+    pub GSS_C_SEC_CONTEXT_SASL_SSF: Result<*mut gss_OID, ::libloading::Error>,
+    pub GSS_KRB5_NT_PRINCIPAL_NAME: Result<*mut gss_OID, ::libloading::Error>,
+    pub GSS_KRB5_NT_ENTERPRISE_NAME: Result<*mut gss_OID, ::libloading::Error>,
+    pub gss_mech_krb5: Result<*mut gss_OID, ::libloading::Error>,
+    pub gss_mech_krb5_old: Result<*mut gss_OID, ::libloading::Error>,
+    pub gss_mech_krb5_wrong: Result<*mut gss_OID, ::libloading::Error>,
+    pub gss_mech_iakerb: Result<*mut gss_OID, ::libloading::Error>,
+    pub gss_mech_set_krb5: Result<*mut gss_OID_set, ::libloading::Error>,
+    pub gss_mech_set_krb5_old: Result<*mut gss_OID_set, ::libloading::Error>,
+    pub gss_mech_set_krb5_both: Result<*mut gss_OID_set, ::libloading::Error>,
+    pub gss_nt_krb5_name: Result<*mut gss_OID, ::libloading::Error>,
+    pub gss_nt_krb5_principal: Result<*mut gss_OID, ::libloading::Error>,
+    pub GSS_KRB5_CRED_NO_CI_FLAGS_X: Result<*mut gss_OID, ::libloading::Error>,
+    pub GSS_KRB5_GET_CRED_IMPERSONATOR: Result<*mut gss_OID, ::libloading::Error>,
     pub gss_krb5_get_tkt_flags: Result<
         unsafe extern "C" fn(
             minor_status: *mut OM_uint32,
@@ -672,8 +1270,22 @@ pub struct GSSAPI {
         ) -> OM_uint32,
         ::libloading::Error,
     >,
-    pub gss_krb5_ui: Result<
-        unsafe extern "C" fn(arg1: *mut OM_uint32, arg2: OM_uint32) -> OM_uint32,
+    pub gss_krb5_set_cred_rcache: Result<
+        unsafe extern "C" fn(
+            minor_status: *mut OM_uint32,
+            cred: gss_cred_id_t,
+            rcache: krb5_rcache,
+        ) -> OM_uint32,
+        ::libloading::Error,
+    >,
+    pub gss_krb5_import_cred: Result<
+        unsafe extern "C" fn(
+            minor_status: *mut OM_uint32,
+            id: krb5_ccache,
+            keytab_principal: krb5_principal,
+            keytab: krb5_keytab,
+            cred: *mut gss_cred_id_t,
+        ) -> OM_uint32,
         ::libloading::Error,
     >,
 }
@@ -713,9 +1325,6 @@ impl GSSAPI {
             .get::<*mut gss_OID>(b"GSS_C_NT_EXPORT_NAME\0")
             .map(|sym| *sym);
         let gss_acquire_cred = __library.get(b"gss_acquire_cred\0").map(|sym| *sym);
-        let gss_acquire_cred_from = __library
-            .get(b"gss_acquire_cred_from\0")
-            .map(|sym| *sym);
         let gss_release_cred = __library.get(b"gss_release_cred\0").map(|sym| *sym);
         let gss_init_sec_context = __library.get(b"gss_init_sec_context\0").map(|sym| *sym);
         let gss_accept_sec_context = __library.get(b"gss_accept_sec_context\0").map(|sym| *sym);
@@ -739,6 +1348,7 @@ impl GSSAPI {
         let gss_inquire_cred = __library.get(b"gss_inquire_cred\0").map(|sym| *sym);
         let gss_inquire_context = __library.get(b"gss_inquire_context\0").map(|sym| *sym);
         let gss_wrap_size_limit = __library.get(b"gss_wrap_size_limit\0").map(|sym| *sym);
+        let gss_import_name_object = __library.get(b"gss_import_name_object\0").map(|sym| *sym);
         let gss_export_name_object = __library.get(b"gss_export_name_object\0").map(|sym| *sym);
         let gss_add_cred = __library.get(b"gss_add_cred\0").map(|sym| *sym);
         let gss_inquire_cred_by_mech = __library.get(b"gss_inquire_cred_by_mech\0").map(|sym| *sym);
@@ -763,29 +1373,225 @@ impl GSSAPI {
         let gss_export_name = __library.get(b"gss_export_name\0").map(|sym| *sym);
         let gss_duplicate_name = __library.get(b"gss_duplicate_name\0").map(|sym| *sym);
         let gss_canonicalize_name = __library.get(b"gss_canonicalize_name\0").map(|sym| *sym);
+        let gss_pseudo_random = __library.get(b"gss_pseudo_random\0").map(|sym| *sym);
+        let gss_store_cred = __library.get(b"gss_store_cred\0").map(|sym| *sym);
+        let gss_set_neg_mechs = __library.get(b"gss_set_neg_mechs\0").map(|sym| *sym);
+        let gss_indicate_mechs_by_attrs = __library
+            .get(b"gss_indicate_mechs_by_attrs\0")
+            .map(|sym| *sym);
+        let gss_inquire_attrs_for_mech = __library
+            .get(b"gss_inquire_attrs_for_mech\0")
+            .map(|sym| *sym);
+        let gss_display_mech_attr = __library.get(b"gss_display_mech_attr\0").map(|sym| *sym);
+        let GSS_C_MA_MECH_CONCRETE = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_MECH_CONCRETE\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_MECH_PSEUDO = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_MECH_PSEUDO\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_MECH_COMPOSITE = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_MECH_COMPOSITE\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_MECH_NEGO = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_MECH_NEGO\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_MECH_GLUE = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_MECH_GLUE\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_NOT_MECH = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_NOT_MECH\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_DEPRECATED = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_DEPRECATED\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_NOT_DFLT_MECH = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_NOT_DFLT_MECH\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_ITOK_FRAMED = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_ITOK_FRAMED\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_AUTH_INIT = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_AUTH_INIT\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_AUTH_TARG = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_AUTH_TARG\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_AUTH_INIT_INIT = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_AUTH_INIT_INIT\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_AUTH_TARG_INIT = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_AUTH_TARG_INIT\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_AUTH_INIT_ANON = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_AUTH_INIT_ANON\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_AUTH_TARG_ANON = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_AUTH_TARG_ANON\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_DELEG_CRED = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_DELEG_CRED\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_INTEG_PROT = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_INTEG_PROT\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_CONF_PROT = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_CONF_PROT\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_MIC = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_MIC\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_WRAP = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_WRAP\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_PROT_READY = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_PROT_READY\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_REPLAY_DET = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_REPLAY_DET\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_OOS_DET = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_OOS_DET\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_CBINDINGS = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_CBINDINGS\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_PFS = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_PFS\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_COMPRESS = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_COMPRESS\0")
+            .map(|sym| *sym);
+        let GSS_C_MA_CTX_TRANS = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_CTX_TRANS\0")
+            .map(|sym| *sym);
+        let gss_inquire_saslname_for_mech = __library
+            .get(b"gss_inquire_saslname_for_mech\0")
+            .map(|sym| *sym);
+        let gss_inquire_mech_for_saslname = __library
+            .get(b"gss_inquire_mech_for_saslname\0")
+            .map(|sym| *sym);
+        let gss_pname_to_uid = __library.get(b"gss_pname_to_uid\0").map(|sym| *sym);
+        let gss_localname = __library.get(b"gss_localname\0").map(|sym| *sym);
+        let gss_userok = __library.get(b"gss_userok\0").map(|sym| *sym);
+        let gss_authorize_localname = __library.get(b"gss_authorize_localname\0").map(|sym| *sym);
+        let gss_acquire_cred_with_password = __library
+            .get(b"gss_acquire_cred_with_password\0")
+            .map(|sym| *sym);
+        let gss_add_cred_with_password = __library
+            .get(b"gss_add_cred_with_password\0")
+            .map(|sym| *sym);
+        let gss_create_empty_buffer_set = __library
+            .get(b"gss_create_empty_buffer_set\0")
+            .map(|sym| *sym);
+        let gss_add_buffer_set_member = __library
+            .get(b"gss_add_buffer_set_member\0")
+            .map(|sym| *sym);
+        let gss_release_buffer_set = __library.get(b"gss_release_buffer_set\0").map(|sym| *sym);
+        let gss_inquire_sec_context_by_oid = __library
+            .get(b"gss_inquire_sec_context_by_oid\0")
+            .map(|sym| *sym);
+        let gss_inquire_cred_by_oid = __library.get(b"gss_inquire_cred_by_oid\0").map(|sym| *sym);
+        let gss_set_sec_context_option = __library
+            .get(b"gss_set_sec_context_option\0")
+            .map(|sym| *sym);
+        let gss_export_cred = __library.get(b"gss_export_cred\0").map(|sym| *sym);
+        let gss_import_cred = __library.get(b"gss_import_cred\0").map(|sym| *sym);
+        let gss_set_cred_option = __library.get(b"gss_set_cred_option\0").map(|sym| *sym);
+        let gss_wrap_aead = __library.get(b"gss_wrap_aead\0").map(|sym| *sym);
+        let gss_unwrap_aead = __library.get(b"gss_unwrap_aead\0").map(|sym| *sym);
+        let GSS_C_INQ_SSPI_SESSION_KEY = __library
+            .get::<*mut gss_OID>(b"GSS_C_INQ_SSPI_SESSION_KEY\0")
+            .map(|sym| *sym);
+        let GSS_C_INQ_NEGOEX_KEY = __library
+            .get::<*mut gss_OID>(b"GSS_C_INQ_NEGOEX_KEY\0")
+            .map(|sym| *sym);
+        let GSS_C_INQ_NEGOEX_VERIFY_KEY = __library
+            .get::<*mut gss_OID>(b"GSS_C_INQ_NEGOEX_VERIFY_KEY\0")
+            .map(|sym| *sym);
+        let gss_complete_auth_token = __library.get(b"gss_complete_auth_token\0").map(|sym| *sym);
+        let gss_wrap_iov = __library.get(b"gss_wrap_iov\0").map(|sym| *sym);
+        let gss_unwrap_iov = __library.get(b"gss_unwrap_iov\0").map(|sym| *sym);
+        let gss_wrap_iov_length = __library.get(b"gss_wrap_iov_length\0").map(|sym| *sym);
+        let gss_get_mic_iov = __library.get(b"gss_get_mic_iov\0").map(|sym| *sym);
+        let gss_get_mic_iov_length = __library.get(b"gss_get_mic_iov_length\0").map(|sym| *sym);
+        let gss_verify_mic_iov = __library.get(b"gss_verify_mic_iov\0").map(|sym| *sym);
+        let gss_release_iov_buffer = __library.get(b"gss_release_iov_buffer\0").map(|sym| *sym);
+        let gss_acquire_cred_impersonate_name = __library
+            .get(b"gss_acquire_cred_impersonate_name\0")
+            .map(|sym| *sym);
+        let gss_add_cred_impersonate_name = __library
+            .get(b"gss_add_cred_impersonate_name\0")
+            .map(|sym| *sym);
+        let GSS_C_ATTR_LOCAL_LOGIN_USER = __library
+            .get::<*mut gss_buffer_t>(b"GSS_C_ATTR_LOCAL_LOGIN_USER\0")
+            .map(|sym| *sym);
+        let GSS_C_NT_COMPOSITE_EXPORT = __library
+            .get::<*mut gss_OID>(b"GSS_C_NT_COMPOSITE_EXPORT\0")
+            .map(|sym| *sym);
+        let gss_display_name_ext = __library.get(b"gss_display_name_ext\0").map(|sym| *sym);
+        let gss_inquire_name = __library.get(b"gss_inquire_name\0").map(|sym| *sym);
+        let gss_get_name_attribute = __library.get(b"gss_get_name_attribute\0").map(|sym| *sym);
+        let gss_set_name_attribute = __library.get(b"gss_set_name_attribute\0").map(|sym| *sym);
+        let gss_delete_name_attribute = __library
+            .get(b"gss_delete_name_attribute\0")
+            .map(|sym| *sym);
+        let gss_export_name_composite = __library
+            .get(b"gss_export_name_composite\0")
+            .map(|sym| *sym);
+        let gss_map_name_to_any = __library.get(b"gss_map_name_to_any\0").map(|sym| *sym);
+        let gss_release_any_name_mapping = __library
+            .get(b"gss_release_any_name_mapping\0")
+            .map(|sym| *sym);
+        let gss_encapsulate_token = __library.get(b"gss_encapsulate_token\0").map(|sym| *sym);
+        let gss_decapsulate_token = __library.get(b"gss_decapsulate_token\0").map(|sym| *sym);
+        let gss_oid_equal = __library.get(b"gss_oid_equal\0").map(|sym| *sym);
+        let gss_acquire_cred_from = __library.get(b"gss_acquire_cred_from\0").map(|sym| *sym);
+        let gss_add_cred_from = __library.get(b"gss_add_cred_from\0").map(|sym| *sym);
+        let gss_store_cred_into = __library.get(b"gss_store_cred_into\0").map(|sym| *sym);
+        let GSS_C_MA_NEGOEX_AND_SPNEGO = __library
+            .get::<*mut gss_const_OID>(b"GSS_C_MA_NEGOEX_AND_SPNEGO\0")
+            .map(|sym| *sym);
+        let GSS_C_SEC_CONTEXT_SASL_SSF = __library
+            .get::<*mut gss_OID>(b"GSS_C_SEC_CONTEXT_SASL_SSF\0")
+            .map(|sym| *sym);
         let GSS_KRB5_NT_PRINCIPAL_NAME = __library
-            .get::<*mut *const gss_OID_desc>(b"GSS_KRB5_NT_PRINCIPAL_NAME\0")
+            .get::<*mut gss_OID>(b"GSS_KRB5_NT_PRINCIPAL_NAME\0")
+            .map(|sym| *sym);
+        let GSS_KRB5_NT_ENTERPRISE_NAME = __library
+            .get::<*mut gss_OID>(b"GSS_KRB5_NT_ENTERPRISE_NAME\0")
             .map(|sym| *sym);
         let gss_mech_krb5 = __library
-            .get::<*mut *const gss_OID_desc>(b"gss_mech_krb5\0")
+            .get::<*mut gss_OID>(b"gss_mech_krb5\0")
             .map(|sym| *sym);
         let gss_mech_krb5_old = __library
-            .get::<*mut *const gss_OID_desc>(b"gss_mech_krb5_old\0")
+            .get::<*mut gss_OID>(b"gss_mech_krb5_old\0")
+            .map(|sym| *sym);
+        let gss_mech_krb5_wrong = __library
+            .get::<*mut gss_OID>(b"gss_mech_krb5_wrong\0")
+            .map(|sym| *sym);
+        let gss_mech_iakerb = __library
+            .get::<*mut gss_OID>(b"gss_mech_iakerb\0")
             .map(|sym| *sym);
         let gss_mech_set_krb5 = __library
-            .get::<*mut *const gss_OID_set_desc>(b"gss_mech_set_krb5\0")
+            .get::<*mut gss_OID_set>(b"gss_mech_set_krb5\0")
             .map(|sym| *sym);
         let gss_mech_set_krb5_old = __library
-            .get::<*mut *const gss_OID_set_desc>(b"gss_mech_set_krb5_old\0")
+            .get::<*mut gss_OID_set>(b"gss_mech_set_krb5_old\0")
             .map(|sym| *sym);
         let gss_mech_set_krb5_both = __library
-            .get::<*mut *const gss_OID_set_desc>(b"gss_mech_set_krb5_both\0")
+            .get::<*mut gss_OID_set>(b"gss_mech_set_krb5_both\0")
             .map(|sym| *sym);
         let gss_nt_krb5_name = __library
-            .get::<*mut *const gss_OID_desc>(b"gss_nt_krb5_name\0")
+            .get::<*mut gss_OID>(b"gss_nt_krb5_name\0")
             .map(|sym| *sym);
         let gss_nt_krb5_principal = __library
-            .get::<*mut *const gss_OID_desc>(b"gss_nt_krb5_principal\0")
+            .get::<*mut gss_OID>(b"gss_nt_krb5_principal\0")
+            .map(|sym| *sym);
+        let GSS_KRB5_CRED_NO_CI_FLAGS_X = __library
+            .get::<*mut gss_OID>(b"GSS_KRB5_CRED_NO_CI_FLAGS_X\0")
+            .map(|sym| *sym);
+        let GSS_KRB5_GET_CRED_IMPERSONATOR = __library
+            .get::<*mut gss_OID>(b"GSS_KRB5_GET_CRED_IMPERSONATOR\0")
             .map(|sym| *sym);
         let gss_krb5_get_tkt_flags = __library.get(b"gss_krb5_get_tkt_flags\0").map(|sym| *sym);
         let gss_krb5_copy_ccache = __library.get(b"gss_krb5_copy_ccache\0").map(|sym| *sym);
@@ -799,7 +1605,8 @@ impl GSSAPI {
         let gss_krb5_free_lucid_sec_context = __library
             .get(b"gss_krb5_free_lucid_sec_context\0")
             .map(|sym| *sym);
-        let gss_krb5_ui = __library.get(b"gss_krb5_ui\0").map(|sym| *sym);
+        let gss_krb5_set_cred_rcache = __library.get(b"gss_krb5_set_cred_rcache\0").map(|sym| *sym);
+        let gss_krb5_import_cred = __library.get(b"gss_krb5_import_cred\0").map(|sym| *sym);
         Ok(GSSAPI {
             __library,
             GSS_C_NT_USER_NAME,
@@ -810,7 +1617,6 @@ impl GSSAPI {
             GSS_C_NT_ANONYMOUS,
             GSS_C_NT_EXPORT_NAME,
             gss_acquire_cred,
-            gss_acquire_cred_from,
             gss_release_cred,
             gss_init_sec_context,
             gss_accept_sec_context,
@@ -832,6 +1638,7 @@ impl GSSAPI {
             gss_inquire_cred,
             gss_inquire_context,
             gss_wrap_size_limit,
+            gss_import_name_object,
             gss_export_name_object,
             gss_add_cred,
             gss_inquire_cred_by_mech,
@@ -852,21 +1659,110 @@ impl GSSAPI {
             gss_export_name,
             gss_duplicate_name,
             gss_canonicalize_name,
+            gss_pseudo_random,
+            gss_store_cred,
+            gss_set_neg_mechs,
+            gss_indicate_mechs_by_attrs,
+            gss_inquire_attrs_for_mech,
+            gss_display_mech_attr,
+            GSS_C_MA_MECH_CONCRETE,
+            GSS_C_MA_MECH_PSEUDO,
+            GSS_C_MA_MECH_COMPOSITE,
+            GSS_C_MA_MECH_NEGO,
+            GSS_C_MA_MECH_GLUE,
+            GSS_C_MA_NOT_MECH,
+            GSS_C_MA_DEPRECATED,
+            GSS_C_MA_NOT_DFLT_MECH,
+            GSS_C_MA_ITOK_FRAMED,
+            GSS_C_MA_AUTH_INIT,
+            GSS_C_MA_AUTH_TARG,
+            GSS_C_MA_AUTH_INIT_INIT,
+            GSS_C_MA_AUTH_TARG_INIT,
+            GSS_C_MA_AUTH_INIT_ANON,
+            GSS_C_MA_AUTH_TARG_ANON,
+            GSS_C_MA_DELEG_CRED,
+            GSS_C_MA_INTEG_PROT,
+            GSS_C_MA_CONF_PROT,
+            GSS_C_MA_MIC,
+            GSS_C_MA_WRAP,
+            GSS_C_MA_PROT_READY,
+            GSS_C_MA_REPLAY_DET,
+            GSS_C_MA_OOS_DET,
+            GSS_C_MA_CBINDINGS,
+            GSS_C_MA_PFS,
+            GSS_C_MA_COMPRESS,
+            GSS_C_MA_CTX_TRANS,
+            gss_inquire_saslname_for_mech,
+            gss_inquire_mech_for_saslname,
+            gss_pname_to_uid,
+            gss_localname,
+            gss_userok,
+            gss_authorize_localname,
+            gss_acquire_cred_with_password,
+            gss_add_cred_with_password,
+            gss_create_empty_buffer_set,
+            gss_add_buffer_set_member,
+            gss_release_buffer_set,
+            gss_inquire_sec_context_by_oid,
+            gss_inquire_cred_by_oid,
+            gss_set_sec_context_option,
+            gss_export_cred,
+            gss_import_cred,
+            gss_set_cred_option,
+            gss_wrap_aead,
+            gss_unwrap_aead,
+            GSS_C_INQ_SSPI_SESSION_KEY,
+            GSS_C_INQ_NEGOEX_KEY,
+            GSS_C_INQ_NEGOEX_VERIFY_KEY,
+            gss_complete_auth_token,
+            gss_wrap_iov,
+            gss_unwrap_iov,
+            gss_wrap_iov_length,
+            gss_get_mic_iov,
+            gss_get_mic_iov_length,
+            gss_verify_mic_iov,
+            gss_release_iov_buffer,
+            gss_acquire_cred_impersonate_name,
+            gss_add_cred_impersonate_name,
+            GSS_C_ATTR_LOCAL_LOGIN_USER,
+            GSS_C_NT_COMPOSITE_EXPORT,
+            gss_display_name_ext,
+            gss_inquire_name,
+            gss_get_name_attribute,
+            gss_set_name_attribute,
+            gss_delete_name_attribute,
+            gss_export_name_composite,
+            gss_map_name_to_any,
+            gss_release_any_name_mapping,
+            gss_encapsulate_token,
+            gss_decapsulate_token,
+            gss_oid_equal,
+            gss_acquire_cred_from,
+            gss_add_cred_from,
+            gss_store_cred_into,
+            GSS_C_MA_NEGOEX_AND_SPNEGO,
+            GSS_C_SEC_CONTEXT_SASL_SSF,
             GSS_KRB5_NT_PRINCIPAL_NAME,
+            GSS_KRB5_NT_ENTERPRISE_NAME,
             gss_mech_krb5,
             gss_mech_krb5_old,
+            gss_mech_krb5_wrong,
+            gss_mech_iakerb,
             gss_mech_set_krb5,
             gss_mech_set_krb5_old,
             gss_mech_set_krb5_both,
             gss_nt_krb5_name,
             gss_nt_krb5_principal,
+            GSS_KRB5_CRED_NO_CI_FLAGS_X,
+            GSS_KRB5_GET_CRED_IMPERSONATOR,
             gss_krb5_get_tkt_flags,
             gss_krb5_copy_ccache,
             gss_krb5_ccache_name,
             gss_krb5_set_allowable_enctypes,
             gss_krb5_export_lucid_sec_context,
             gss_krb5_free_lucid_sec_context,
-            gss_krb5_ui,
+            gss_krb5_set_cred_rcache,
+            gss_krb5_import_cred,
         })
     }
     pub unsafe fn GSS_C_NT_USER_NAME(&self) -> *mut gss_OID {
@@ -927,25 +1823,6 @@ impl GSSAPI {
             .as_ref()
             .expect("Expected function, got error."))(
             arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8,
-        )
-    }
-    pub unsafe fn gss_acquire_cred_from(
-        &self,
-        arg1: *mut OM_uint32,
-        arg2: gss_name_t,
-        arg3: OM_uint32,
-        arg4: gss_OID_set,
-        arg5: gss_cred_usage_t,
-        arg6: gss_const_key_value_set_t,
-        arg7: *mut gss_cred_id_t,
-        arg8: *mut gss_OID_set,
-        arg9: *mut OM_uint32,
-    ) -> OM_uint32 {
-        (self
-            .gss_acquire_cred_from
-            .as_ref()
-            .expect("Expected function, got error."))(
-            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
         )
     }
     pub unsafe fn gss_release_cred(
@@ -1225,6 +2102,18 @@ impl GSSAPI {
             .as_ref()
             .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5, arg6)
     }
+    pub unsafe fn gss_import_name_object(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: *mut ::std::os::raw::c_void,
+        arg3: gss_OID,
+        arg4: *mut gss_name_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_import_name_object
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4)
+    }
     pub unsafe fn gss_export_name_object(
         &self,
         arg1: *mut OM_uint32,
@@ -1471,51 +2360,961 @@ impl GSSAPI {
             .as_ref()
             .expect("Expected function, got error."))(arg1, arg2, arg3, arg4)
     }
-    pub unsafe fn GSS_KRB5_NT_PRINCIPAL_NAME(&self) -> *mut *const gss_OID_desc {
+    pub unsafe fn gss_pseudo_random(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_ctx_id_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: gss_buffer_t,
+        arg5: isize,
+        arg6: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_pseudo_random
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5, arg6)
+    }
+    pub unsafe fn gss_store_cred(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_cred_id_t,
+        arg3: gss_cred_usage_t,
+        arg4: gss_OID,
+        arg5: OM_uint32,
+        arg6: OM_uint32,
+        arg7: *mut gss_OID_set,
+        arg8: *mut gss_cred_usage_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_store_cred
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8,
+        )
+    }
+    pub unsafe fn gss_set_neg_mechs(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_cred_id_t,
+        arg3: gss_OID_set,
+    ) -> OM_uint32 {
+        (self
+            .gss_set_neg_mechs
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3)
+    }
+    pub unsafe fn gss_indicate_mechs_by_attrs(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_const_OID_set,
+        arg3: gss_const_OID_set,
+        arg4: gss_const_OID_set,
+        arg5: *mut gss_OID_set,
+    ) -> OM_uint32 {
+        (self
+            .gss_indicate_mechs_by_attrs
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5)
+    }
+    pub unsafe fn gss_inquire_attrs_for_mech(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_const_OID,
+        arg3: *mut gss_OID_set,
+        arg4: *mut gss_OID_set,
+    ) -> OM_uint32 {
+        (self
+            .gss_inquire_attrs_for_mech
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4)
+    }
+    pub unsafe fn gss_display_mech_attr(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_const_OID,
+        arg3: gss_buffer_t,
+        arg4: gss_buffer_t,
+        arg5: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_display_mech_attr
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5)
+    }
+    pub unsafe fn GSS_C_MA_MECH_CONCRETE(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_MECH_CONCRETE
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_MECH_PSEUDO(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_MECH_PSEUDO
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_MECH_COMPOSITE(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_MECH_COMPOSITE
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_MECH_NEGO(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_MECH_NEGO
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_MECH_GLUE(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_MECH_GLUE
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_NOT_MECH(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_NOT_MECH
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_DEPRECATED(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_DEPRECATED
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_NOT_DFLT_MECH(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_NOT_DFLT_MECH
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_ITOK_FRAMED(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_ITOK_FRAMED
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_AUTH_INIT(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_AUTH_INIT
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_AUTH_TARG(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_AUTH_TARG
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_AUTH_INIT_INIT(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_AUTH_INIT_INIT
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_AUTH_TARG_INIT(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_AUTH_TARG_INIT
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_AUTH_INIT_ANON(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_AUTH_INIT_ANON
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_AUTH_TARG_ANON(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_AUTH_TARG_ANON
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_DELEG_CRED(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_DELEG_CRED
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_INTEG_PROT(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_INTEG_PROT
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_CONF_PROT(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_CONF_PROT
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_MIC(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_MIC
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_WRAP(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_WRAP
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_PROT_READY(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_PROT_READY
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_REPLAY_DET(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_REPLAY_DET
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_OOS_DET(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_OOS_DET
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_CBINDINGS(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_CBINDINGS
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_PFS(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_PFS
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_COMPRESS(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_COMPRESS
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_MA_CTX_TRANS(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_CTX_TRANS
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn gss_inquire_saslname_for_mech(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_OID,
+        arg3: gss_buffer_t,
+        arg4: gss_buffer_t,
+        arg5: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_inquire_saslname_for_mech
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5)
+    }
+    pub unsafe fn gss_inquire_mech_for_saslname(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_buffer_t,
+        arg3: *mut gss_OID,
+    ) -> OM_uint32 {
+        (self
+            .gss_inquire_mech_for_saslname
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3)
+    }
+    pub unsafe fn gss_pname_to_uid(
+        &self,
+        minor: *mut OM_uint32,
+        name: gss_name_t,
+        mech_type: gss_OID,
+        uidOut: *mut uid_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_pname_to_uid
+            .as_ref()
+            .expect("Expected function, got error."))(minor, name, mech_type, uidOut)
+    }
+    pub unsafe fn gss_localname(
+        &self,
+        minor: *mut OM_uint32,
+        name: gss_name_t,
+        mech_type: gss_const_OID,
+        localname: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_localname
+            .as_ref()
+            .expect("Expected function, got error."))(minor, name, mech_type, localname)
+    }
+    pub unsafe fn gss_userok(
+        &self,
+        name: gss_name_t,
+        username: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int {
+        (self
+            .gss_userok
+            .as_ref()
+            .expect("Expected function, got error."))(name, username)
+    }
+    pub unsafe fn gss_authorize_localname(
+        &self,
+        minor: *mut OM_uint32,
+        name: gss_name_t,
+        user: gss_name_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_authorize_localname
+            .as_ref()
+            .expect("Expected function, got error."))(minor, name, user)
+    }
+    pub unsafe fn gss_acquire_cred_with_password(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: gss_buffer_t,
+        arg4: OM_uint32,
+        arg5: gss_OID_set,
+        arg6: gss_cred_usage_t,
+        arg7: *mut gss_cred_id_t,
+        arg8: *mut gss_OID_set,
+        arg9: *mut OM_uint32,
+    ) -> OM_uint32 {
+        (self
+            .gss_acquire_cred_with_password
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+        )
+    }
+    pub unsafe fn gss_add_cred_with_password(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_cred_id_t,
+        arg3: gss_name_t,
+        arg4: gss_OID,
+        arg5: gss_buffer_t,
+        arg6: gss_cred_usage_t,
+        arg7: OM_uint32,
+        arg8: OM_uint32,
+        arg9: *mut gss_cred_id_t,
+        arg10: *mut gss_OID_set,
+        arg11: *mut OM_uint32,
+        arg12: *mut OM_uint32,
+    ) -> OM_uint32 {
+        (self
+            .gss_add_cred_with_password
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12,
+        )
+    }
+    pub unsafe fn gss_create_empty_buffer_set(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: *mut gss_buffer_set_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_create_empty_buffer_set
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2)
+    }
+    pub unsafe fn gss_add_buffer_set_member(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_buffer_t,
+        arg3: *mut gss_buffer_set_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_add_buffer_set_member
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3)
+    }
+    pub unsafe fn gss_release_buffer_set(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: *mut gss_buffer_set_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_release_buffer_set
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2)
+    }
+    pub unsafe fn gss_inquire_sec_context_by_oid(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_ctx_id_t,
+        arg3: gss_OID,
+        arg4: *mut gss_buffer_set_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_inquire_sec_context_by_oid
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4)
+    }
+    pub unsafe fn gss_inquire_cred_by_oid(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_cred_id_t,
+        arg3: gss_OID,
+        arg4: *mut gss_buffer_set_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_inquire_cred_by_oid
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4)
+    }
+    pub unsafe fn gss_set_sec_context_option(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: *mut gss_ctx_id_t,
+        arg3: gss_OID,
+        arg4: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_set_sec_context_option
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4)
+    }
+    pub unsafe fn gss_export_cred(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_cred_id_t,
+        arg3: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_export_cred
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3)
+    }
+    pub unsafe fn gss_import_cred(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_buffer_t,
+        arg3: *mut gss_cred_id_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_import_cred
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3)
+    }
+    pub unsafe fn gss_set_cred_option(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: *mut gss_cred_id_t,
+        arg3: gss_OID,
+        arg4: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_set_cred_option
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4)
+    }
+    pub unsafe fn gss_wrap_aead(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_ctx_id_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: gss_qop_t,
+        arg5: gss_buffer_t,
+        arg6: gss_buffer_t,
+        arg7: *mut ::std::os::raw::c_int,
+        arg8: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_wrap_aead
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8,
+        )
+    }
+    pub unsafe fn gss_unwrap_aead(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_ctx_id_t,
+        arg3: gss_buffer_t,
+        arg4: gss_buffer_t,
+        arg5: gss_buffer_t,
+        arg6: *mut ::std::os::raw::c_int,
+        arg7: *mut gss_qop_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_unwrap_aead
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7
+        )
+    }
+    pub unsafe fn GSS_C_INQ_SSPI_SESSION_KEY(&self) -> *mut gss_OID {
+        *self
+            .GSS_C_INQ_SSPI_SESSION_KEY
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_INQ_NEGOEX_KEY(&self) -> *mut gss_OID {
+        *self
+            .GSS_C_INQ_NEGOEX_KEY
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_INQ_NEGOEX_VERIFY_KEY(&self) -> *mut gss_OID {
+        *self
+            .GSS_C_INQ_NEGOEX_VERIFY_KEY
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn gss_complete_auth_token(
+        &self,
+        minor_status: *mut OM_uint32,
+        context_handle: gss_ctx_id_t,
+        input_message_buffer: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_complete_auth_token
+            .as_ref()
+            .expect("Expected function, got error."))(
+            minor_status,
+            context_handle,
+            input_message_buffer,
+        )
+    }
+    pub unsafe fn gss_wrap_iov(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_ctx_id_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: gss_qop_t,
+        arg5: *mut ::std::os::raw::c_int,
+        arg6: *mut gss_iov_buffer_desc,
+        arg7: ::std::os::raw::c_int,
+    ) -> OM_uint32 {
+        (self
+            .gss_wrap_iov
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7
+        )
+    }
+    pub unsafe fn gss_unwrap_iov(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_ctx_id_t,
+        arg3: *mut ::std::os::raw::c_int,
+        arg4: *mut gss_qop_t,
+        arg5: *mut gss_iov_buffer_desc,
+        arg6: ::std::os::raw::c_int,
+    ) -> OM_uint32 {
+        (self
+            .gss_unwrap_iov
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5, arg6)
+    }
+    pub unsafe fn gss_wrap_iov_length(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_ctx_id_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: gss_qop_t,
+        arg5: *mut ::std::os::raw::c_int,
+        arg6: *mut gss_iov_buffer_desc,
+        arg7: ::std::os::raw::c_int,
+    ) -> OM_uint32 {
+        (self
+            .gss_wrap_iov_length
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7
+        )
+    }
+    pub unsafe fn gss_get_mic_iov(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_ctx_id_t,
+        arg3: gss_qop_t,
+        arg4: *mut gss_iov_buffer_desc,
+        arg5: ::std::os::raw::c_int,
+    ) -> OM_uint32 {
+        (self
+            .gss_get_mic_iov
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5)
+    }
+    pub unsafe fn gss_get_mic_iov_length(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_ctx_id_t,
+        arg3: gss_qop_t,
+        arg4: *mut gss_iov_buffer_desc,
+        arg5: ::std::os::raw::c_int,
+    ) -> OM_uint32 {
+        (self
+            .gss_get_mic_iov_length
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5)
+    }
+    pub unsafe fn gss_verify_mic_iov(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_ctx_id_t,
+        arg3: *mut gss_qop_t,
+        arg4: *mut gss_iov_buffer_desc,
+        arg5: ::std::os::raw::c_int,
+    ) -> OM_uint32 {
+        (self
+            .gss_verify_mic_iov
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5)
+    }
+    pub unsafe fn gss_release_iov_buffer(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: *mut gss_iov_buffer_desc,
+        arg3: ::std::os::raw::c_int,
+    ) -> OM_uint32 {
+        (self
+            .gss_release_iov_buffer
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3)
+    }
+    pub unsafe fn gss_acquire_cred_impersonate_name(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_cred_id_t,
+        arg3: gss_name_t,
+        arg4: OM_uint32,
+        arg5: gss_OID_set,
+        arg6: gss_cred_usage_t,
+        arg7: *mut gss_cred_id_t,
+        arg8: *mut gss_OID_set,
+        arg9: *mut OM_uint32,
+    ) -> OM_uint32 {
+        (self
+            .gss_acquire_cred_impersonate_name
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+        )
+    }
+    pub unsafe fn gss_add_cred_impersonate_name(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_cred_id_t,
+        arg3: gss_cred_id_t,
+        arg4: gss_name_t,
+        arg5: gss_OID,
+        arg6: gss_cred_usage_t,
+        arg7: OM_uint32,
+        arg8: OM_uint32,
+        arg9: *mut gss_cred_id_t,
+        arg10: *mut gss_OID_set,
+        arg11: *mut OM_uint32,
+        arg12: *mut OM_uint32,
+    ) -> OM_uint32 {
+        (self
+            .gss_add_cred_impersonate_name
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12,
+        )
+    }
+    pub unsafe fn GSS_C_ATTR_LOCAL_LOGIN_USER(&self) -> *mut gss_buffer_t {
+        *self
+            .GSS_C_ATTR_LOCAL_LOGIN_USER
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_NT_COMPOSITE_EXPORT(&self) -> *mut gss_OID {
+        *self
+            .GSS_C_NT_COMPOSITE_EXPORT
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn gss_display_name_ext(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: gss_OID,
+        arg4: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_display_name_ext
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4)
+    }
+    pub unsafe fn gss_inquire_name(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: *mut ::std::os::raw::c_int,
+        arg4: *mut gss_OID,
+        arg5: *mut gss_buffer_set_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_inquire_name
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5)
+    }
+    pub unsafe fn gss_get_name_attribute(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: gss_buffer_t,
+        arg4: *mut ::std::os::raw::c_int,
+        arg5: *mut ::std::os::raw::c_int,
+        arg6: gss_buffer_t,
+        arg7: gss_buffer_t,
+        arg8: *mut ::std::os::raw::c_int,
+    ) -> OM_uint32 {
+        (self
+            .gss_get_name_attribute
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8,
+        )
+    }
+    pub unsafe fn gss_set_name_attribute(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: gss_buffer_t,
+        arg5: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_set_name_attribute
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5)
+    }
+    pub unsafe fn gss_delete_name_attribute(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_delete_name_attribute
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3)
+    }
+    pub unsafe fn gss_export_name_composite(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_export_name_composite
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3)
+    }
+    pub unsafe fn gss_map_name_to_any(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: ::std::os::raw::c_int,
+        arg4: gss_buffer_t,
+        arg5: *mut gss_any_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_map_name_to_any
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4, arg5)
+    }
+    pub unsafe fn gss_release_any_name_mapping(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: gss_buffer_t,
+        arg4: *mut gss_any_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_release_any_name_mapping
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3, arg4)
+    }
+    pub unsafe fn gss_encapsulate_token(
+        &self,
+        arg1: gss_const_buffer_t,
+        arg2: gss_const_OID,
+        arg3: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_encapsulate_token
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3)
+    }
+    pub unsafe fn gss_decapsulate_token(
+        &self,
+        arg1: gss_const_buffer_t,
+        arg2: gss_const_OID,
+        arg3: gss_buffer_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_decapsulate_token
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2, arg3)
+    }
+    pub unsafe fn gss_oid_equal(
+        &self,
+        arg1: gss_const_OID,
+        arg2: gss_const_OID,
+    ) -> ::std::os::raw::c_int {
+        (self
+            .gss_oid_equal
+            .as_ref()
+            .expect("Expected function, got error."))(arg1, arg2)
+    }
+    pub unsafe fn gss_acquire_cred_from(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_name_t,
+        arg3: OM_uint32,
+        arg4: gss_OID_set,
+        arg5: gss_cred_usage_t,
+        arg6: gss_const_key_value_set_t,
+        arg7: *mut gss_cred_id_t,
+        arg8: *mut gss_OID_set,
+        arg9: *mut OM_uint32,
+    ) -> OM_uint32 {
+        (self
+            .gss_acquire_cred_from
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+        )
+    }
+    pub unsafe fn gss_add_cred_from(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_cred_id_t,
+        arg3: gss_name_t,
+        arg4: gss_OID,
+        arg5: gss_cred_usage_t,
+        arg6: OM_uint32,
+        arg7: OM_uint32,
+        arg8: gss_const_key_value_set_t,
+        arg9: *mut gss_cred_id_t,
+        arg10: *mut gss_OID_set,
+        arg11: *mut OM_uint32,
+        arg12: *mut OM_uint32,
+    ) -> OM_uint32 {
+        (self
+            .gss_add_cred_from
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12,
+        )
+    }
+    pub unsafe fn gss_store_cred_into(
+        &self,
+        arg1: *mut OM_uint32,
+        arg2: gss_cred_id_t,
+        arg3: gss_cred_usage_t,
+        arg4: gss_OID,
+        arg5: OM_uint32,
+        arg6: OM_uint32,
+        arg7: gss_const_key_value_set_t,
+        arg8: *mut gss_OID_set,
+        arg9: *mut gss_cred_usage_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_store_cred_into
+            .as_ref()
+            .expect("Expected function, got error."))(
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+        )
+    }
+    pub unsafe fn GSS_C_MA_NEGOEX_AND_SPNEGO(&self) -> *mut gss_const_OID {
+        *self
+            .GSS_C_MA_NEGOEX_AND_SPNEGO
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_C_SEC_CONTEXT_SASL_SSF(&self) -> *mut gss_OID {
+        *self
+            .GSS_C_SEC_CONTEXT_SASL_SSF
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_KRB5_NT_PRINCIPAL_NAME(&self) -> *mut gss_OID {
         *self
             .GSS_KRB5_NT_PRINCIPAL_NAME
             .as_ref()
             .expect("Expected variable, got error.")
     }
-    pub unsafe fn gss_mech_krb5(&self) -> *mut *const gss_OID_desc {
+    pub unsafe fn GSS_KRB5_NT_ENTERPRISE_NAME(&self) -> *mut gss_OID {
+        *self
+            .GSS_KRB5_NT_ENTERPRISE_NAME
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn gss_mech_krb5(&self) -> *mut gss_OID {
         *self
             .gss_mech_krb5
             .as_ref()
             .expect("Expected variable, got error.")
     }
-    pub unsafe fn gss_mech_krb5_old(&self) -> *mut *const gss_OID_desc {
+    pub unsafe fn gss_mech_krb5_old(&self) -> *mut gss_OID {
         *self
             .gss_mech_krb5_old
             .as_ref()
             .expect("Expected variable, got error.")
     }
-    pub unsafe fn gss_mech_set_krb5(&self) -> *mut *const gss_OID_set_desc {
+    pub unsafe fn gss_mech_krb5_wrong(&self) -> *mut gss_OID {
+        *self
+            .gss_mech_krb5_wrong
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn gss_mech_iakerb(&self) -> *mut gss_OID {
+        *self
+            .gss_mech_iakerb
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn gss_mech_set_krb5(&self) -> *mut gss_OID_set {
         *self
             .gss_mech_set_krb5
             .as_ref()
             .expect("Expected variable, got error.")
     }
-    pub unsafe fn gss_mech_set_krb5_old(&self) -> *mut *const gss_OID_set_desc {
+    pub unsafe fn gss_mech_set_krb5_old(&self) -> *mut gss_OID_set {
         *self
             .gss_mech_set_krb5_old
             .as_ref()
             .expect("Expected variable, got error.")
     }
-    pub unsafe fn gss_mech_set_krb5_both(&self) -> *mut *const gss_OID_set_desc {
+    pub unsafe fn gss_mech_set_krb5_both(&self) -> *mut gss_OID_set {
         *self
             .gss_mech_set_krb5_both
             .as_ref()
             .expect("Expected variable, got error.")
     }
-    pub unsafe fn gss_nt_krb5_name(&self) -> *mut *const gss_OID_desc {
+    pub unsafe fn gss_nt_krb5_name(&self) -> *mut gss_OID {
         *self
             .gss_nt_krb5_name
             .as_ref()
             .expect("Expected variable, got error.")
     }
-    pub unsafe fn gss_nt_krb5_principal(&self) -> *mut *const gss_OID_desc {
+    pub unsafe fn gss_nt_krb5_principal(&self) -> *mut gss_OID {
         *self
             .gss_nt_krb5_principal
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_KRB5_CRED_NO_CI_FLAGS_X(&self) -> *mut gss_OID {
+        *self
+            .GSS_KRB5_CRED_NO_CI_FLAGS_X
+            .as_ref()
+            .expect("Expected variable, got error.")
+    }
+    pub unsafe fn GSS_KRB5_GET_CRED_IMPERSONATOR(&self) -> *mut gss_OID {
+        *self
+            .GSS_KRB5_GET_CRED_IMPERSONATOR
             .as_ref()
             .expect("Expected variable, got error.")
     }
@@ -1590,10 +3389,34 @@ impl GSSAPI {
             .as_ref()
             .expect("Expected function, got error."))(minor_status, kctx)
     }
-    pub unsafe fn gss_krb5_ui(&self, arg1: *mut OM_uint32, arg2: OM_uint32) -> OM_uint32 {
+    pub unsafe fn gss_krb5_set_cred_rcache(
+        &self,
+        minor_status: *mut OM_uint32,
+        cred: gss_cred_id_t,
+        rcache: krb5_rcache,
+    ) -> OM_uint32 {
         (self
-            .gss_krb5_ui
+            .gss_krb5_set_cred_rcache
             .as_ref()
-            .expect("Expected function, got error."))(arg1, arg2)
+            .expect("Expected function, got error."))(minor_status, cred, rcache)
+    }
+    pub unsafe fn gss_krb5_import_cred(
+        &self,
+        minor_status: *mut OM_uint32,
+        id: krb5_ccache,
+        keytab_principal: krb5_principal,
+        keytab: krb5_keytab,
+        cred: *mut gss_cred_id_t,
+    ) -> OM_uint32 {
+        (self
+            .gss_krb5_import_cred
+            .as_ref()
+            .expect("Expected function, got error."))(
+            minor_status,
+            id,
+            keytab_principal,
+            keytab,
+            cred,
+        )
     }
 }

--- a/rust/src/security/kms.rs
+++ b/rust/src/security/kms.rs
@@ -46,6 +46,7 @@ use url::Url;
 use crate::common::config::{Configuration, HADOOP_SECURITY_KEY_PROVIDER_PATH};
 use crate::hdfs::crypto::DataEncryptionKey;
 use crate::proto::hdfs::FileEncryptionInfoProto;
+use crate::security::ClientAuth;
 use crate::security::gssapi::SpnegoSession;
 use crate::{HdfsError, Result};
 
@@ -63,6 +64,7 @@ pub(crate) struct KmsClient {
     /// is cached (KMS simple-auth mode). Also the renewer requested when we
     /// fetch a delegation token under Kerberos.
     user: String,
+    auth: Option<Arc<ClientAuth>>,
     /// Cached delegation token. `None` until the first time a request is
     /// rejected with 401 (Kerberos KMS) and then populated for the lifetime of
     /// the client. The mutex serialises concurrent first-time fetches.
@@ -76,6 +78,7 @@ impl KmsClient {
         config: &Configuration,
         server_default_uri: Option<&str>,
         user: String,
+        auth: Option<Arc<ClientAuth>>,
     ) -> Result<Option<Arc<Self>>> {
         let raw = config
             .get(HADOOP_SECURITY_KEY_PROVIDER_PATH)
@@ -105,6 +108,7 @@ impl KmsClient {
             http,
             next: AtomicUsize::new(0),
             user,
+            auth,
             delegation_token: tokio::sync::Mutex::new(None),
         })))
     }
@@ -276,7 +280,7 @@ impl KmsClient {
     /// Drive a SPNEGO challenge/response handshake against a `GET` endpoint,
     /// returning the final non-401 response.
     async fn spnego_get(&self, url: &Url, host: &str) -> Result<reqwest::Response> {
-        let mut session = SpnegoSession::new(SPNEGO_SERVICE, host)?;
+        let mut session = SpnegoSession::new(SPNEGO_SERVICE, host, self.auth.clone())?;
         let mut server_token: Option<Vec<u8>> = None;
 
         // Bound the loop so a misbehaving server can't spin forever.
@@ -565,7 +569,7 @@ mod tests {
     #[test]
     fn from_config_returns_none_when_unset() {
         let cfg = config_with(HashMap::new());
-        let client = KmsClient::from_config(&cfg, None, "testuser".to_string()).unwrap();
+        let client = KmsClient::from_config(&cfg, None, "testuser".to_string(), None).unwrap();
         assert!(client.is_none());
     }
 
@@ -577,7 +581,7 @@ mod tests {
             "kms://http@kms.example.com:9292/kms".to_string(),
         );
         let cfg = config_with(map);
-        let client = KmsClient::from_config(&cfg, None, "testuser".to_string())
+        let client = KmsClient::from_config(&cfg, None, "testuser".to_string(), None)
             .unwrap()
             .unwrap();
         assert_eq!(client.endpoints.len(), 1);
@@ -590,6 +594,7 @@ mod tests {
             &cfg,
             Some("kms://http@kms:9292/kms"),
             "testuser".to_string(),
+            None,
         )
         .unwrap()
         .unwrap();
@@ -627,7 +632,7 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(HADOOP_SECURITY_KEY_PROVIDER_PATH.to_string(), uri);
         let cfg = config_with(map);
-        let client = KmsClient::from_config(&cfg, None, "testuser".to_string())
+        let client = KmsClient::from_config(&cfg, None, "testuser".to_string(), None)
             .unwrap()
             .unwrap();
 
@@ -669,6 +674,7 @@ mod tests {
                 .unwrap(),
             next: AtomicUsize::new(0),
             user: "testuser".to_string(),
+            auth: None,
             delegation_token: tokio::sync::Mutex::new(None),
         };
 
@@ -687,7 +693,7 @@ mod tests {
         let uri = format!("kms://http@{}/kms", server.address());
         let mut map = HashMap::new();
         map.insert(HADOOP_SECURITY_KEY_PROVIDER_PATH.to_string(), uri);
-        let client = KmsClient::from_config(&config_with(map), None, "testuser".to_string())
+        let client = KmsClient::from_config(&config_with(map), None, "testuser".to_string(), None)
             .unwrap()
             .unwrap();
 
@@ -717,6 +723,7 @@ mod tests {
                 .unwrap(),
             next: AtomicUsize::new(0),
             user: "testuser".to_string(),
+            auth: None,
             delegation_token: tokio::sync::Mutex::new(Some("deadbeef".to_string())),
         };
 
@@ -760,7 +767,7 @@ mod tests {
         let uri = format!("kms://http@{}/kms", server.address());
         let mut map = HashMap::new();
         map.insert(HADOOP_SECURITY_KEY_PROVIDER_PATH.to_string(), uri);
-        let client = KmsClient::from_config(&config_with(map), None, "testuser".to_string())
+        let client = KmsClient::from_config(&config_with(map), None, "testuser".to_string(), None)
             .unwrap()
             .unwrap();
 
@@ -788,7 +795,7 @@ mod tests {
         let uri = format!("kms://http@{}/kms", server.address());
         let mut map = HashMap::new();
         map.insert(HADOOP_SECURITY_KEY_PROVIDER_PATH.to_string(), uri);
-        let client = KmsClient::from_config(&config_with(map), None, "testuser".to_string())
+        let client = KmsClient::from_config(&config_with(map), None, "testuser".to_string(), None)
             .unwrap()
             .unwrap();
 

--- a/rust/src/security/mod.rs
+++ b/rust/src/security/mod.rs
@@ -5,6 +5,10 @@ pub(crate) mod kms;
 pub mod sasl;
 pub mod user;
 
+use std::sync::Arc;
+
+use crate::Result;
+
 /// Kerberos credentials to use for a single HDFS client.
 ///
 /// The fields are independent: a keytab and cache may be supplied together so
@@ -18,27 +22,57 @@ pub(crate) struct KerberosCredentials {
     pub cache: Option<String>,
 }
 
-#[derive(Clone)]
-pub(crate) struct ResolvedKerberosCredentials {
-    pub(crate) principal: Option<String>,
-    pub(crate) keytab: Option<String>,
-    pub(crate) cache: Option<String>,
-}
-
 impl KerberosCredentials {
-    pub(crate) fn resolve(self) -> Option<ResolvedKerberosCredentials> {
-        if self.principal.is_none() && self.keytab.is_none() && self.cache.is_none() {
-            return None;
+    pub(crate) fn new(
+        principal: Option<String>,
+        keytab: Option<String>,
+        cache: Option<String>,
+    ) -> Result<Option<Self>> {
+        if principal.is_none() && keytab.is_none() && cache.is_none() {
+            // Calling the explicit-credentials builder with all fields unset is
+            // deliberately equivalent to not calling it. This preserves the
+            // existing process-default GSSAPI behavior.
+            return Ok(None);
         }
-        let cache = match (&self.keytab, self.cache) {
+        if principal.is_none() {
+            return Err(crate::HdfsError::InvalidArgument(
+                "Kerberos principal is required when keytab or cache credentials are supplied"
+                    .to_string(),
+            ));
+        }
+        if principal.as_deref().is_some_and(str::is_empty) {
+            return Err(crate::HdfsError::InvalidArgument(
+                "Kerberos principal must not be empty".to_string(),
+            ));
+        }
+        let cache = match (&keytab, cache) {
             (Some(_), None) => Some(format!("MEMORY:hdfs-native-{}", uuid::Uuid::new_v4())),
             (_, cache) => cache,
         };
-        Some(ResolvedKerberosCredentials {
-            principal: self.principal,
-            keytab: self.keytab,
+        Ok(Some(Self {
+            principal,
+            keytab,
             cache,
-        })
+        }))
+    }
+}
+
+/// Authentication state shared by every connection belonging to one client.
+///
+/// GSS credential handles remain session-local; this context owns the
+/// per-client credential configuration used to acquire them.
+#[derive(Debug)]
+pub(crate) struct ClientAuth {
+    pub(crate) kerberos: KerberosCredentials,
+}
+
+impl ClientAuth {
+    pub(crate) fn new(kerberos: KerberosCredentials) -> Arc<Self> {
+        Arc::new(Self { kerberos })
+    }
+
+    pub(crate) fn credentials(&self) -> Option<&KerberosCredentials> {
+        Some(&self.kerberos)
     }
 }
 
@@ -52,34 +86,26 @@ impl std::fmt::Debug for KerberosCredentials {
     }
 }
 
-impl std::fmt::Debug for ResolvedKerberosCredentials {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ResolvedKerberosCredentials")
-            .field("principal", &self.principal)
-            .field("keytab", &self.keytab.as_ref().map(|_| "[REDACTED]"))
-            .field("cache", &self.cache.as_ref().map(|_| "[REDACTED]"))
-            .finish()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::KerberosCredentials;
 
     #[test]
     fn kerberos_credentials_are_composable_and_redacted() {
-        let credentials = KerberosCredentials {
-            principal: Some("alice@EXAMPLE.COM".to_string()),
-            keytab: Some("/run/secrets/alice.keytab".to_string()),
-            cache: Some("FILE:/run/krb5/alice.ccache".to_string()),
-        };
+        let credentials = KerberosCredentials::new(
+            Some("alice@EXAMPLE.COM".to_string()),
+            Some("/run/secrets/alice.keytab".to_string()),
+            Some("FILE:/run/krb5/alice.ccache".to_string()),
+        )
+        .unwrap()
+        .unwrap();
 
         let debug = format!("{credentials:?}");
         assert!(debug.contains("alice@EXAMPLE.COM"));
         assert!(!debug.contains("/run/secrets/alice.keytab"));
         assert!(!debug.contains("/run/krb5/alice.ccache"));
 
-        let resolved = credentials.resolve().unwrap();
+        let resolved = credentials;
         assert_eq!(
             resolved.keytab.as_deref(),
             Some("/run/secrets/alice.keytab")
@@ -92,12 +118,12 @@ mod tests {
 
     #[test]
     fn keytab_without_cache_gets_private_memory_cache() {
-        let resolved = KerberosCredentials {
-            principal: None,
-            keytab: Some("/run/secrets/alice.keytab".to_string()),
-            cache: None,
-        }
-        .resolve()
+        let resolved = KerberosCredentials::new(
+            Some("alice@EXAMPLE.COM".to_string()),
+            Some("/run/secrets/alice.keytab".to_string()),
+            None,
+        )
+        .unwrap()
         .unwrap();
 
         assert!(resolved.cache.unwrap().starts_with("MEMORY:hdfs-native-"));
@@ -105,6 +131,18 @@ mod tests {
 
     #[test]
     fn empty_credentials_use_default_path() {
-        assert!(KerberosCredentials::default().resolve().is_none());
+        assert!(
+            KerberosCredentials::new(None, None, None)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn explicit_credentials_require_a_principal() {
+        let error =
+            KerberosCredentials::new(None, Some("/run/secrets/alice.keytab".to_string()), None)
+                .unwrap_err();
+        assert!(error.to_string().contains("principal is required"));
     }
 }

--- a/rust/src/security/sasl.rs
+++ b/rust/src/security/sasl.rs
@@ -73,7 +73,7 @@ pub(crate) async fn negotiate_sasl_session(
     service: &str,
     config: &Configuration,
     effective_user: Option<String>,
-    kerberos_credentials: Option<&crate::security::ResolvedKerberosCredentials>,
+    auth: Option<std::sync::Arc<crate::security::ClientAuth>>,
 ) -> Result<(UserInfo, SaslReader, SaslWriter)> {
     let (reader, writer) = stream.into_split();
     let mut reader = SaslReader::new(reader);
@@ -102,7 +102,7 @@ pub(crate) async fn negotiate_sasl_session(
                     &message.auths,
                     service,
                     effective_user.clone(),
-                    kerberos_credentials,
+                    auth.clone(),
                 )?;
                 session = selected_session;
 
@@ -187,7 +187,7 @@ fn select_method(
     auths: &[SaslAuth],
     service: &str,
     effective_user: Option<String>,
-    kerberos_credentials: Option<&crate::security::ResolvedKerberosCredentials>,
+    client_auth: Option<std::sync::Arc<crate::security::ClientAuth>>,
 ) -> Result<(SaslAuth, Option<Box<dyn SaslSession>>)> {
     let user = User::get();
     for auth in auths.iter() {
@@ -203,11 +203,11 @@ fn select_method(
                     auth.protocol(),
                     auth.server_id(),
                     effective_user,
-                    kerberos_credentials,
+                    client_auth.clone(),
                 )?;
                 return Ok((auth.clone(), Some(Box::new(session))));
             }
-            (Some(AuthMethod::Token), Some(token)) if kerberos_credentials.is_none() => {
+            (Some(AuthMethod::Token), Some(token)) if client_auth.is_none() => {
                 let session = DigestSaslSession::from_token(
                     auth.protocol().to_string(),
                     auth.server_id().to_string(),

--- a/rust/src/sync.rs
+++ b/rust/src/sync.rs
@@ -80,25 +80,6 @@ impl ClientBuilder {
         self
     }
 
-    /// Set all Kerberos credential fields at once.
-    ///
-    /// Prefer the individual `with_kerberos_*` methods when constructing a
-    /// client incrementally. An explicit principal is required with a keytab
-    /// or cache. A keytab without a cache uses a native `MEMORY:` cache. The
-    /// all-`None` form of the compatibility method preserves the
-    /// process-default GSSAPI behavior.
-    pub fn with_kerberos_credentials(
-        mut self,
-        principal: Option<String>,
-        keytab: Option<String>,
-        cache: Option<String>,
-    ) -> Self {
-        self.inner = self
-            .inner
-            .with_kerberos_credentials(principal, keytab, cache);
-        self
-    }
-
     /// Create the synchronous [`Client`] from the provided settings.
     pub fn build(self) -> Result<Client> {
         let rt = Arc::new(Runtime::new()?);

--- a/rust/src/sync.rs
+++ b/rust/src/sync.rs
@@ -62,7 +62,31 @@ impl ClientBuilder {
         self
     }
 
-    /// Set Kerberos credentials scoped to this client instance.
+    /// Set the Kerberos principal used by this client.
+    pub fn with_kerberos_principal(mut self, principal: impl Into<String>) -> Self {
+        self.inner = self.inner.with_kerberos_principal(principal);
+        self
+    }
+
+    /// Set the Kerberos keytab used by this client.
+    pub fn with_kerberos_keytab(mut self, keytab: impl Into<String>) -> Self {
+        self.inner = self.inner.with_kerberos_keytab(keytab);
+        self
+    }
+
+    /// Set the Kerberos credential cache used by this client.
+    pub fn with_kerberos_cache(mut self, cache: impl Into<String>) -> Self {
+        self.inner = self.inner.with_kerberos_cache(cache);
+        self
+    }
+
+    /// Set all Kerberos credential fields at once.
+    ///
+    /// Prefer the individual `with_kerberos_*` methods when constructing a
+    /// client incrementally. An explicit principal is required with a keytab
+    /// or cache. A keytab without a cache uses a native `MEMORY:` cache. The
+    /// all-`None` form of the compatibility method preserves the
+    /// process-default GSSAPI behavior.
     pub fn with_kerberos_credentials(
         mut self,
         principal: Option<String>,

--- a/rust/tests/test_failover.rs
+++ b/rust/tests/test_failover.rs
@@ -73,11 +73,8 @@ mod test {
         let _dfs = MiniDfs::with_features(&HashSet::from([DfsFeatures::Security, DfsFeatures::HA]));
         let _cache_guard = EnvVarGuard::set("KRB5CCNAME", "FILE:target/test/nonexistent-cache");
         let client = ClientBuilder::new()
-            .with_kerberos_credentials(
-                Some("hdfs/localhost".to_string()),
-                Some("target/test/hdfs.keytab".to_string()),
-                None,
-            )
+            .with_kerberos_principal("hdfs/localhost")
+            .with_kerberos_keytab("target/test/hdfs.keytab")
             .build()?;
 
         client

--- a/rust/tests/test_integration.rs
+++ b/rust/tests/test_integration.rs
@@ -41,11 +41,8 @@ mod test {
 
         let client = ClientBuilder::new()
             .with_url(&dfs.url)
-            .with_kerberos_credentials(
-                Some("hdfs/localhost".to_string()),
-                Some("target/test/hdfs.keytab".to_string()),
-                None,
-            )
+            .with_kerberos_principal("hdfs/localhost")
+            .with_kerberos_keytab("target/test/hdfs.keytab")
             .build()
             .unwrap();
         assert_explicit_kerberos_io(&client, "/explicit-keytab").await;
@@ -59,11 +56,8 @@ mod test {
 
         let client = ClientBuilder::new()
             .with_url(&dfs.url)
-            .with_kerberos_credentials(
-                Some("hdfs/localhost".to_string()),
-                None,
-                Some("FILE:target/test/krbcache".to_string()),
-            )
+            .with_kerberos_principal("hdfs/localhost")
+            .with_kerberos_cache("FILE:target/test/krbcache")
             .build()
             .unwrap();
         assert_explicit_kerberos_io(&client, "/explicit-cache").await;
@@ -77,11 +71,9 @@ mod test {
 
         let client = ClientBuilder::new()
             .with_url(&dfs.url)
-            .with_kerberos_credentials(
-                Some("hdfs/localhost".to_string()),
-                Some("target/test/hdfs.keytab".to_string()),
-                Some("FILE:target/test/explicit-keytab-cache".to_string()),
-            )
+            .with_kerberos_principal("hdfs/localhost")
+            .with_kerberos_keytab("target/test/hdfs.keytab")
+            .with_kerberos_cache("FILE:target/test/explicit-keytab-cache")
             .build()
             .unwrap();
         assert_explicit_kerberos_io(&client, "/explicit-keytab-cache").await;


### PR DESCRIPTION
Some follow up updates to https://github.com/Kimahriman/hdfs-native/pull/320
- Split out the public client methods into individual methods per principal/keytab/cache
- Consolidate KerberosCredentials and ResolvedKerberosCredentials into a single struct
- Create a `ClientAuth` wrapper struct that could hold delegation tokens in the future
- Propagate custom credentials to SPNEGO auth for KMS
- Generate full gssapi_ext bindings
- Add Python API for custom credentials